### PR TITLE
Bind pairing engine responses

### DIFF
--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -41,14 +41,9 @@ final class PairingEngine {
         removeRespondedPendingPairings()
         restoreSubscriptions()
         
-        relayer.onPairingApproveResponse = { [weak self] in
-            try? self?.acknowledgeApproval(pendingTopic: $0)
+        relayer.onResponse = { [weak self] in
+            self?.handleReponse($0)
         }
-        
-        // TODO: Bind on response
-//        relayer.onResponse = { [weak self] in
-//            print($0.topic)
-//        }
     }
     
     func hasPairing(for topic: String) -> Bool {
@@ -316,6 +311,15 @@ final class PairingEngine {
             } else {
                 self?.logger.debug("successfully responded with error")
             }
+        }
+    }
+    
+    private func handleReponse(_ response: WCResponse) {
+        switch response.requestParams {
+        case .pairingApprove:
+            try? acknowledgeApproval(pendingTopic: response.topic)
+        default:
+            break
         }
     }
 }

--- a/Sources/WalletConnect/Relay/WalletConnectRelay.swift
+++ b/Sources/WalletConnect/Relay/WalletConnectRelay.swift
@@ -12,7 +12,6 @@ struct WCResponse {
 
 protocol WalletConnectRelaying: AnyObject {
     var onResponse: ((WCResponse) -> Void)? {get set}
-    var onPairingApproveResponse: ((String) -> Void)? {get set}
     var transportConnectionPublisher: AnyPublisher<Void, Never> {get}
     var wcRequestPublisher: AnyPublisher<WCRequestSubscriptionPayload, Never> {get}
     func request(topic: String, payload: WCRequest, completion: @escaping ((Result<JSONRPCResponse<AnyCodable>, JSONRPCErrorResponse>)->()))
@@ -24,7 +23,6 @@ protocol WalletConnectRelaying: AnyObject {
 class WalletConnectRelay: WalletConnectRelaying {
     
     var onResponse: ((WCResponse) -> Void)?
-    var onPairingApproveResponse: ((String) -> Void)?
     
     private var networkRelayer: NetworkRelaying
     private let jsonRpcSerialiser: JSONRPCSerialising
@@ -75,17 +73,6 @@ class WalletConnectRelay: WalletConnectRelaying {
                             self.logger.debug("WC Relay - received response on topic: \(topic)")
                             switch response {
                             case .response(let response):
-                                // FIXME: This is a workaround to remove the completion block from the engine
-                                switch payload.method {
-                                case .pairingApprove:
-                                    self.onPairingApproveResponse?(topic)
-                                case .pairingPing:
-                                    break
-                                case .pairingUpdate:
-                                    break
-                                default:
-                                    break
-                                }
                                 completion(.success(response))
                             case .error(let error):
                                 self.logger.debug("Request error: \(error)")

--- a/Tests/WalletConnectTests/PairingEngineTests.swift
+++ b/Tests/WalletConnectTests/PairingEngineTests.swift
@@ -122,7 +122,9 @@ final class PairingEngineTests: XCTestCase {
         engine.onApprovalAcknowledgement = { acknowledgedPairing = $0 }
 
         try engine.approve(uri)
-        relayMock.onPairingApproveResponse?(topicA)
+        let success = JSONRPCResponse<AnyCodable>(id: 0, result: AnyCodable(true))
+        let response = WCResponse(topic: topicA, requestMethod: .pairingApprove, requestParams: .pairingApprove(PairingType.ApprovalParams(relay: RelayProtocolOptions(protocol: "", params: nil), responder: PairingParticipant(publicKey: ""), expiry: 0, state: nil)), result: .success(success))
+        relayMock.onResponse?(response)
         
         XCTAssert(storageMock.hasAcknowledgedPairing(on: topicB), "Settled pairing must advance to acknowledged state.")
         XCTAssertFalse(storageMock.hasSequence(forTopic: topicA), "Pending pairing must be deleted.")


### PR DESCRIPTION
Binds pairing engine response acknowledgement to relayer's `onResponse`