### PR TITLE
Fast workaround fix for pairing responses

### DIFF
--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -41,7 +41,7 @@ final class PairingEngine {
         removeRespondedPendingPairings()
         restoreSubscriptions()
         
-        relayer.onResponse = { [weak self] in
+        relayer.onPairingResponse = { [weak self] in
             self?.handleReponse($0)
         }
     }

--- a/Sources/WalletConnect/Relay/WalletConnectRelay.swift
+++ b/Sources/WalletConnect/Relay/WalletConnectRelay.swift
@@ -11,6 +11,7 @@ struct WCResponse {
 }
 
 protocol WalletConnectRelaying: AnyObject {
+    var onPairingResponse: ((WCResponse) -> Void)? {get set} // Temporary workaround
     var onResponse: ((WCResponse) -> Void)? {get set}
     var transportConnectionPublisher: AnyPublisher<Void, Never> {get}
     var wcRequestPublisher: AnyPublisher<WCRequestSubscriptionPayload, Never> {get}
@@ -22,6 +23,7 @@ protocol WalletConnectRelaying: AnyObject {
 
 class WalletConnectRelay: WalletConnectRelaying {
     
+    var onPairingResponse: ((WCResponse) -> Void)?
     var onResponse: ((WCResponse) -> Void)?
     
     private var networkRelayer: NetworkRelaying
@@ -164,6 +166,7 @@ class WalletConnectRelay: WalletConnectRelaying {
                 requestParams: record.request.params,
                 result: .success(response))
             wcResponsePublisherSubject.send(.response(response))
+            onPairingResponse?(wcResponse)
             onResponse?(wcResponse)
         } catch  {
             logger.info("Info: \(error.localizedDescription)")
@@ -179,6 +182,7 @@ class WalletConnectRelay: WalletConnectRelaying {
                 requestParams: record.request.params,
                 result: .failure(response))
             wcResponsePublisherSubject.send(.error(response))
+            onPairingResponse?(wcResponse)
             onResponse?(wcResponse)
         } catch {
             logger.info("Info: \(error.localizedDescription)")

--- a/Tests/WalletConnectTests/Mocks/MockedRelay.swift
+++ b/Tests/WalletConnectTests/Mocks/MockedRelay.swift
@@ -6,6 +6,7 @@ import WalletConnectUtils
 
 class MockedWCRelay: WalletConnectRelaying {
     
+    var onPairingResponse: ((WCResponse) -> Void)?
     var onResponse: ((WCResponse) -> Void)?
     
     var onPairingApproveResponse: ((String) -> Void)?

--- a/Tests/WalletConnectTests/PairingEngineTests.swift
+++ b/Tests/WalletConnectTests/PairingEngineTests.swift
@@ -124,7 +124,7 @@ final class PairingEngineTests: XCTestCase {
         try engine.approve(uri)
         let success = JSONRPCResponse<AnyCodable>(id: 0, result: AnyCodable(true))
         let response = WCResponse(topic: topicA, requestMethod: .pairingApprove, requestParams: .pairingApprove(PairingType.ApprovalParams(relay: RelayProtocolOptions(protocol: "", params: nil), responder: PairingParticipant(publicKey: ""), expiry: 0, state: nil)), result: .success(success))
-        relayMock.onResponse?(response)
+        relayMock.onPairingResponse?(response)
         
         XCTAssert(storageMock.hasAcknowledgedPairing(on: topicB), "Settled pairing must advance to acknowledged state.")
         XCTAssertFalse(storageMock.hasSequence(forTopic: topicA), "Pending pairing must be deleted.")


### PR DESCRIPTION
Fast workaround fix for pairing response handling on failed approval. Needs a better solution in the future.