### PR TITLE
Make `WalletConnectURI` public

### DIFF
--- a/Sources/WalletConnect/Types/WalletConnectURI.swift
+++ b/Sources/WalletConnect/Types/WalletConnectURI.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-struct WalletConnectURI: Equatable {
+public struct WalletConnectURI: Equatable {
     
-    let topic: String
-    let version: String
-    let publicKey: String
-    let isController: Bool
+    public let topic: String
+    public let version: String
+    public let publicKey: String
+    public let isController: Bool
     let relay: RelayProtocolOptions
     
     init(topic: String, publicKey: String, isController: Bool, relay: RelayProtocolOptions) {
@@ -16,7 +16,7 @@ struct WalletConnectURI: Equatable {
         self.relay = relay
     }
     
-    init?(string: String) {
+    public init?(string: String) {
         guard string.hasPrefix("wc:") else {
             return nil
         }
@@ -41,7 +41,7 @@ struct WalletConnectURI: Equatable {
         self.relay = relay
     }
     
-    var absoluteString: String {
+    public var absoluteString: String {
         return "wc:\(topic)@\(version)?controller=\(isController)&publicKey=\(publicKey)&relay=\(relay.asPercentEncodedString())"
     }
 }

--- a/Sources/WalletConnect/WalletConnectClientDelegate.swift
+++ b/Sources/WalletConnect/WalletConnectClientDelegate.swift
@@ -26,7 +26,7 @@ public protocol WalletConnectClientDelegate: AnyObject {
     /// Function is executed on controller and non-controller client when both communicating peers have successfully upgraded permissions.
     func didUpgrade(sessionTopic: String, permissions: Session.Permissions)
     
-    /// Tells the delegate that extra eccounts has been included in session sequence
+    /// Tells the delegate that extra accounts has been included in session sequence
     ///
     /// Function is executed on controller and non-controller client when both communicating peers have successfully included new accounts requested by the controller client.
     func didUpdate(sessionTopic: String, accounts: Set<String>)
@@ -41,7 +41,7 @@ public protocol WalletConnectClientDelegate: AnyObject {
     /// Function is executed on proposer and responder client when both communicating peers have successfully established a pairing.
     func didSettle(pairing: Pairing)
     
-    /// Tells the delegate that sotification has been received.
+    /// Tells the delegate that notification has been received.
     func didReceive(notification: Session.Notification, sessionTopic : String)
     
     /// Tells the delegate that peer client has rejected a session proposal.


### PR DESCRIPTION
We need to pass around `WalletConnectURI` before paring and typed uri is always safer than `string`, also it might better to have a `public func pair(uri: WalletConnectURI)` method in `WalletConnectClient`