### PR TITLE
#96 Move secure random bytes generator to Utils

### DIFF
--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -16,7 +16,7 @@ final class PairingEngine {
     private var publishers = [AnyCancellable]()
     private let logger: ConsoleLogging
     private var sessionPermissions: [String: SessionPermissions] = [:]
-    private let topicInitializer: () -> String?
+    private let topicInitializer: () -> String
     
     init(relay: WalletConnectRelaying,
          kms: KeyManagementServiceProtocol,
@@ -24,7 +24,7 @@ final class PairingEngine {
          sequencesStore: PairingSequenceStorage,
          metadata: AppMetadata,
          logger: ConsoleLogging,
-         topicGenerator: @escaping () -> String? = String.generateTopic) {
+         topicGenerator: @escaping () -> String = String.generateTopic) {
         self.relayer = relay
         self.kms = kms
         self.wcSubscriber = subscriber
@@ -55,9 +55,7 @@ final class PairingEngine {
     }
     
     func create() -> WalletConnectURI? {
-        guard let topic = topicInitializer() else {
-            return nil
-        }
+        let topic = topicInitializer()
         let symKey = try! kms.createSymmetricKey(topic)
         let pairing = PairingSequence.build(topic)
         let uri = WalletConnectURI(topic: topic, symKey: symKey.hexRepresentation, relay: pairing.relay)

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -22,7 +22,7 @@ final class SessionEngine {
     private var metadata: AppMetadata
     private var publishers = [AnyCancellable]()
     private let logger: ConsoleLogging
-    private let topicInitializer: () -> String?
+    private let topicInitializer: () -> String
 
     init(relay: WalletConnectRelaying,
          kms: KeyManagementServiceProtocol,
@@ -30,7 +30,7 @@ final class SessionEngine {
          sequencesStore: SessionSequenceStorage,
          metadata: AppMetadata,
          logger: ConsoleLogging,
-         topicGenerator: @escaping () -> String? = String.generateTopic) {
+         topicGenerator: @escaping () -> String = String.generateTopic) {
         self.relayer = relay
         self.kms = kms
         self.metadata = metadata
@@ -60,10 +60,7 @@ final class SessionEngine {
     }
         
     func proposeSession(settledPairing: Pairing, permissions: SessionPermissions, relay: RelayProtocolOptions) {
-        guard let pendingSessionTopic = topicInitializer() else {
-            logger.debug("Could not generate topic")
-            return
-        }
+        let pendingSessionTopic = topicInitializer()
         logger.debug("Propose Session on topic: \(pendingSessionTopic)")
         
         let publicKey = try! kms.createX25519KeyPair()

--- a/Sources/WalletConnect/Extensions/String+Extension.swift
+++ b/Sources/WalletConnect/Extensions/String+Extension.swift
@@ -29,14 +29,7 @@ extension String {
     }
     
     static func generateTopic() -> String {
-        var keyData = Data(count: 32)
-        let result = keyData.withUnsafeMutableBytes {
-            SecRandomCopyBytes(kSecRandomDefault, 32, $0.baseAddress!)
-        }
-        guard result == errSecSuccess else {
-            fatalError("Failed to generate secure random bytes.")
-        }
+        let keyData = Data.randomBytes(count: 32)
         return keyData.toHexString()
     }
 }
-

--- a/Sources/WalletConnect/Extensions/String+Extension.swift
+++ b/Sources/WalletConnect/Extensions/String+Extension.swift
@@ -28,16 +28,15 @@ extension String {
         return isNamespaceValid && isReferenceValid && isAddressValid
     }
     
-    static func generateTopic() -> String? {
+    static func generateTopic() -> String {
         var keyData = Data(count: 32)
         let result = keyData.withUnsafeMutableBytes {
             SecRandomCopyBytes(kSecRandomDefault, 32, $0.baseAddress!)
         }
-        if result == errSecSuccess {
-            return keyData.toHexString()
-        } else {
-            return nil
+        guard result == errSecSuccess else {
+            fatalError("Failed to generate secure random bytes.")
         }
+        return keyData.toHexString()
     }
 }
 

--- a/Sources/WalletConnectKMS/Crypto/Random.swift
+++ b/Sources/WalletConnectKMS/Crypto/Random.swift
@@ -6,17 +6,6 @@ import Security
 
 extension AES {
     static func randomIV(count: Int = 16) -> Data {
-        return Data.randomBytes(count)
-    }
-}
-
-extension Data {
-    public static func randomBytes(_ count: Int) -> Data {
-        var randomBytes = [UInt8](repeating: 0, count: count)
-        let status = SecRandomCopyBytes(kSecRandomDefault, count, &randomBytes)
-        if status != errSecSuccess {
-            fatalError("can't generate secure random data")
-        }
-        return Data(randomBytes)
+        return Data.randomBytes(count: count)
     }
 }

--- a/Sources/WalletConnectUtils/Data+Extension.swift
+++ b/Sources/WalletConnectUtils/Data+Extension.swift
@@ -1,6 +1,20 @@
-//
-
 import Foundation
+
+// MARK: - Random data generation
+
+extension Data {
+    
+    public static func randomBytes(count: Int) -> Data {
+        var buffer = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &buffer)
+        guard status == errSecSuccess else {
+            fatalError("Failed to generate secure random data of size \(count).")
+        }
+        return Data(buffer)
+    }
+}
+
+// MARK: - Hexadecimal string conversion
 
 extension Data {
 

--- a/Tests/WalletConnectKMSTests/AgreementSecret+Stub.swift
+++ b/Tests/WalletConnectKMSTests/AgreementSecret+Stub.swift
@@ -4,6 +4,6 @@ import Foundation
 extension AgreementSecret {
     
     static func stub() -> AgreementSecret {
-        AgreementSecret(sharedSecret: Data.randomBytes(32), publicKey: AgreementPrivateKey().publicKey)
+        AgreementSecret(sharedSecret: Data.randomBytes(count: 32), publicKey: AgreementPrivateKey().publicKey)
     }
 }

--- a/Tests/WalletConnectTests/Helpers/TopicGenerator.swift
+++ b/Tests/WalletConnectTests/Helpers/TopicGenerator.swift
@@ -4,11 +4,11 @@ final class TopicGenerator {
     
     let topic: String
     
-    init(topic: String = String.generateTopic()!) {
+    init(topic: String = String.generateTopic()) {
         self.topic = topic
     }
     
-    func getTopic() -> String? {
+    func getTopic() -> String {
         return topic
     }
 }

--- a/Tests/WalletConnectTests/SequenceStoreTests.swift
+++ b/Tests/WalletConnectTests/SequenceStoreTests.swift
@@ -35,7 +35,7 @@ final class SequenceStoreTests: XCTestCase {
     
     private func stubSequence(expiry: TimeInterval? = nil) -> ExpirableSequenceStub {
         ExpirableSequenceStub(
-            topic: String.generateTopic()!,
+            topic: String.generateTopic(),
             publicKey: "0x",
             expiryDate: timeTraveler.referenceDate.addingTimeInterval(expiry ?? defaultTime)
         )

--- a/Tests/WalletConnectTests/SessionEngineTests.swift
+++ b/Tests/WalletConnectTests/SessionEngineTests.swift
@@ -116,8 +116,8 @@ final class SessionEngineTests: XCTestCase {
     func testApprove() {
         setupEngine()
         let proposerPubKey = AgreementPrivateKey().publicKey.hexRepresentation
-        let topicB = String.generateTopic()!
-        let topicC = String.generateTopic()!
+        let topicB = String.generateTopic()
+        let topicC = String.generateTopic()
         let topicD = deriveTopic(publicKey: proposerPubKey, privateKey: cryptoMock.privateKeyStub)
         
         let proposer = SessionType.Proposer(publicKey: proposerPubKey, controller: true, metadata: metadata)
@@ -148,8 +148,8 @@ final class SessionEngineTests: XCTestCase {
         setupEngine()
         
         let proposerPubKey = AgreementPrivateKey().publicKey.hexRepresentation
-        let topicB = String.generateTopic()!
-        let topicC = String.generateTopic()!
+        let topicB = String.generateTopic()
+        let topicC = String.generateTopic()
         let topicD = deriveTopic(publicKey: proposerPubKey, privateKey: cryptoMock.privateKeyStub)
         
         let agreementKeys = AgreementSecret.stub()
@@ -188,8 +188,8 @@ final class SessionEngineTests: XCTestCase {
         
         let proposerPubKey = AgreementPrivateKey().publicKey.hexRepresentation
         let selfPubKey = cryptoMock.privateKeyStub.publicKey.hexRepresentation
-        let topicB = String.generateTopic()!
-        let topicC = String.generateTopic()!
+        let topicB = String.generateTopic()
+        let topicC = String.generateTopic()
         let topicD = deriveTopic(publicKey: proposerPubKey, privateKey: cryptoMock.privateKeyStub)
         
         let agreementKeys = AgreementSecret.stub()

--- a/Tests/WalletConnectTests/Stub/AgreementSecret+Stub.swift
+++ b/Tests/WalletConnectTests/Stub/AgreementSecret+Stub.swift
@@ -4,6 +4,6 @@ import Foundation
 extension AgreementSecret {
     
     static func stub() -> AgreementSecret {
-        AgreementSecret(sharedSecret: Data.randomBytes(32), publicKey: AgreementPrivateKey().publicKey)
+        AgreementSecret(sharedSecret: Data.randomBytes(count: 32), publicKey: AgreementPrivateKey().publicKey)
     }
 }

--- a/Tests/WalletConnectTests/Stub/Session+Stub.swift
+++ b/Tests/WalletConnectTests/Stub/Session+Stub.swift
@@ -11,7 +11,7 @@ extension SessionSequence {
             let selfKey = AgreementPrivateKey().publicKey.hexRepresentation
             let permissions = isSelfController ? SessionPermissions.stub(controllerKey: selfKey) : SessionPermissions.stub(controllerKey: peerKey)
         return SessionSequence(
-            topic: String.generateTopic()!,
+            topic: String.generateTopic(),
             relay: RelayProtocolOptions.stub(),
             selfParticipant: Participant.stub(publicKey: selfKey),
             expiryDate: expiryDate,
@@ -31,7 +31,7 @@ extension SessionSequence {
         let selfKey = AgreementPrivateKey().publicKey.hexRepresentation
         let permissions = isSelfController ? SessionPermissions.stub(controllerKey: selfKey) : SessionPermissions.stub(controllerKey: peerKey)
         return SessionSequence(
-            topic: String.generateTopic()!,
+            topic: String.generateTopic(),
             relay: RelayProtocolOptions.stub(),
             selfParticipant: Participant.stub(publicKey: selfKey),
             expiryDate: expiryDate,

--- a/Tests/WalletConnectTests/Stub/Stubs.swift
+++ b/Tests/WalletConnectTests/Stub/Stubs.swift
@@ -15,7 +15,7 @@ extension AppMetadata {
 
 extension Pairing {
     static func stub(expiryDate: Date = Date(timeIntervalSinceNow: 10000)) -> Pairing {
-        Pairing(topic: String.generateTopic()!, peer: nil, expiryDate: expiryDate)
+        Pairing(topic: String.generateTopic(), peer: nil, expiryDate: expiryDate)
     }
 }
 

--- a/Tests/WalletConnectTests/Stub/WalletConnectURI+Stub.swift
+++ b/Tests/WalletConnectTests/Stub/WalletConnectURI+Stub.swift
@@ -6,7 +6,7 @@ extension WalletConnectURI {
     
     static func stub(isController: Bool = false) -> WalletConnectURI {
         WalletConnectURI(
-            topic: String.generateTopic()!,
+            topic: String.generateTopic(),
             symKey: SymmetricKey().hexRepresentation,
             relay: RelayProtocolOptions(protocol: "", data: nil)
         )


### PR DESCRIPTION
closes #96

Moves the security random bytes generator function to the Utils package. Also removes the optional return, as generating secure random data is a premise to the protocol standard.