### PR TITLE
Remove optionals from AppMetadata, adds documentation

### DIFF
--- a/Sources/WalletConnect/Types/Common/AppMetadata.swift
+++ b/Sources/WalletConnect/Types/Common/AppMetadata.swift
@@ -1,17 +1,42 @@
 
 import Foundation
 
-/// App metadata object that describes application metadata.
+/**
+ A structure that identifies a peer connected through a WalletConnect session.
+ 
+ You can provide human-readable information about your app so that it can be shared with a connected peer, for example,
+ during a session proposal event.
+ 
+ This information should make the identity of your app clear to the end-user and easily verifiable. Therefore, it is a
+ suitable place to briefly communicate your brand.
+ */
 public struct AppMetadata: Codable, Equatable {
+    
+    /// The name of the app.
+    public let name: String?
+    
+    /// A brief textual description of the app that can be displayed to peers.
+    public let description: String?
+    
+    /// The URL string that identifies the official domain of the app.
+    public let url: String?
+    
+    /// An array of URL strings pointing to the icon assets on the web.
+    public let icons: [String]?
+    
+    /**
+     Creates a new metadata object with the specified information.
+     
+     - parameters:
+        - name: The name of the app.
+        - description: A brief textual description of the app that can be displayed to peers.
+        - url: The URL string that identifies the official domain of the app.
+        - icons: An array of URL strings pointing to the icon assets on the web.
+     */
     public init(name: String?, description: String?, url: String?, icons: [String]?) {
         self.name = name
         self.description = description
         self.url = url
         self.icons = icons
     }
-    
-    public let name: String?
-    public let description: String?
-    public let url: String?
-    public let icons: [String]?
 }

--- a/Sources/WalletConnect/Types/Common/AppMetadata.swift
+++ b/Sources/WalletConnect/Types/Common/AppMetadata.swift
@@ -13,16 +13,16 @@ import Foundation
 public struct AppMetadata: Codable, Equatable {
     
     /// The name of the app.
-    public let name: String?
+    public let name: String
     
     /// A brief textual description of the app that can be displayed to peers.
-    public let description: String?
+    public let description: String
     
     /// The URL string that identifies the official domain of the app.
-    public let url: String?
+    public let url: String
     
     /// An array of URL strings pointing to the icon assets on the web.
-    public let icons: [String]?
+    public let icons: [String]
     
     /**
      Creates a new metadata object with the specified information.
@@ -33,7 +33,7 @@ public struct AppMetadata: Codable, Equatable {
         - url: The URL string that identifies the official domain of the app.
         - icons: An array of URL strings pointing to the icon assets on the web.
      */
-    public init(name: String?, description: String?, url: String?, icons: [String]?) {
+    public init(name: String, description: String, url: String, icons: [String]) {
         self.name = name
         self.description = description
         self.url = url

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -30,7 +30,7 @@ final class ClientTests: XCTestCase {
         let logger = ConsoleLogger(suffix: prefix, loggingLevel: .debug)
         let keychain = KeychainStorage(keychainService: KeychainServiceFake(), serviceIdentifier: "")
         let client = WalletConnectClient(
-            metadata: AppMetadata(name: nil, description: nil, url: nil, icons: nil),
+            metadata: AppMetadata(name: prefix, description: "", url: "", icons: [""]),
             projectId: projectId,
             relayHost: relayHost,
             logger: logger,

--- a/Tests/WalletConnectTests/PairingEngineTests.swift
+++ b/Tests/WalletConnectTests/PairingEngineTests.swift
@@ -37,7 +37,7 @@ final class PairingEngineTests: XCTestCase {
     }
     
     func setupEngine() {
-        let meta = AppMetadata(name: nil, description: nil, url: nil, icons: nil)
+        let meta = AppMetadata.stub()
         let logger = ConsoleLoggerMock()
         engine = PairingEngine(
             relay: relayMock,

--- a/Tests/WalletConnectTests/SessionEngineTests.swift
+++ b/Tests/WalletConnectTests/SessionEngineTests.swift
@@ -42,7 +42,7 @@ final class SessionEngineTests: XCTestCase {
     }
     
     func setupEngine() {
-        metadata = AppMetadata(name: nil, description: nil, url: nil, icons: nil)
+        metadata = AppMetadata.stub()
         let logger = ConsoleLoggerMock()
         engine = SessionEngine(
             relay: relayMock,

--- a/Tests/WalletConnectTests/Stub/Stubs.swift
+++ b/Tests/WalletConnectTests/Stub/Stubs.swift
@@ -85,7 +85,7 @@ extension SessionProposal {
         let relayOptions = RelayProtocolOptions(protocol: "waku", data: nil)
         return SessionType.ProposeParams(
             relay: relayOptions,
-            proposer: Proposer(publicKey: proposerPubKey, metadata: AppMetadata(name: "", description: "", url: "", icons: nil)),
+            proposer: Proposer(publicKey: proposerPubKey, metadata: AppMetadata.stub()),
             permissions: SessionPermissions.stub(),
             blockchainProposed: BlockchainProposed(chains: []))
     }


### PR DESCRIPTION
All metadata fields are required, so they are being changed to non-optionals.

Also, adds API documentation for the `AppMetadata` struct.