### PR TITLE
CAIP-2 Blockchain Type

### DIFF
--- a/Sources/WalletConnect/Account.swift
+++ b/Sources/WalletConnect/Account.swift
@@ -31,6 +31,7 @@ public struct Account: Equatable, Hashable {
         "\(namespace):\(reference):\(address)"
     }
     
+    /// Returns a CAIP-2 reference to the blockchain where the account is located.
     public var blockchain: Blockchain {
         guard let blockchain = Blockchain(namespace: namespace, reference: reference) else {
             preconditionFailure("The CAIP-2 chain id of a CAIP-10 account must always be consistent.")
@@ -62,6 +63,11 @@ public struct Account: Equatable, Hashable {
         self.init("\(chainIdentifier):\(address)")
     }
     
+    /**
+     Creates an account instance from a blockchain reference and an address.
+     
+     This initializer returns nil if the `address` format is invalid. The `blockchain` type is already expected to be conformant.
+     */
     public init?(blockchain: Blockchain, address: String) {
         self.init("\(blockchain.absoluteString):\(address)")
     }

--- a/Sources/WalletConnect/Account.swift
+++ b/Sources/WalletConnect/Account.swift
@@ -31,6 +31,13 @@ public struct Account: Equatable, Hashable {
         "\(namespace):\(reference):\(address)"
     }
     
+    public var blockchain: Blockchain {
+        guard let blockchain = Blockchain(namespace: namespace, reference: reference) else {
+            preconditionFailure("The CAIP-2 chain id of a CAIP-10 account must always be consistent.")
+        }
+        return blockchain
+    }
+    
     /**
      Creates an account instance from the provided string.
      
@@ -53,6 +60,10 @@ public struct Account: Equatable, Hashable {
      */
     public init?(chainIdentifier: String, address: String) {
         self.init("\(chainIdentifier):\(address)")
+    }
+    
+    public init?(blockchain: Blockchain, address: String) {
+        self.init("\(blockchain.absoluteString):\(address)")
     }
 }
 

--- a/Sources/WalletConnect/Blockchain.swift
+++ b/Sources/WalletConnect/Blockchain.swift
@@ -1,13 +1,32 @@
+/**
+ A value that identifies a blockchain.
+ 
+ This structure parses chain IDs according to [CAIP-2]. A chain ID references a specific blockchain in the ecosystem.
+ 
+ By using chain-agnostic identifiers, different blockchains can be referenced in a standardized way, which aims to provide
+ common semantics to locate resources in the decentralized space in a human readable and transaction-friendly way.
+ 
+ [CAIP-2]:https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+ */
 public struct Blockchain: Equatable {
     
+    /// A blockchain namespace. Usually describes an ecosystem or standard.
     public let namespace: String
     
+    /// A reference string that identifies a blockchain within a given namespace.
     public let reference: String
     
+    /// The CAIP-2 blockchain identifier string.
     public var absoluteString: String {
         "\(namespace):\(reference)"
     }
     
+    /**
+     Creates an instance of a blockchain reference from a string.
+     
+     This initializer returns nil if the string doesn't represent a valid chain id in conformance with
+     [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
+     */
     public init?(_ string: String) {
         guard String.conformsToCAIP2(string) else { return nil }
         let splits = string.split(separator: ":")
@@ -15,6 +34,12 @@ public struct Blockchain: Equatable {
         self.reference = String(splits[1])
     }
     
+    /**
+     Creates an instance of a blockchain reference from a namespace and a reference string.
+     
+     This initializer returns nil if the `namespace` or `reference` strings formats are invalid, according to
+     [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
+     */
     public init?(namespace: String, reference: String) {
         self.init("\(namespace):\(reference)")
     }

--- a/Sources/WalletConnect/Blockchain.swift
+++ b/Sources/WalletConnect/Blockchain.swift
@@ -1,4 +1,4 @@
-public struct Blockchain {
+public struct Blockchain: Equatable {
     
     public let namespace: String
     
@@ -17,5 +17,28 @@ public struct Blockchain {
     
     public init?(namespace: String, reference: String) {
         self.init("\(namespace):\(reference)")
+    }
+}
+
+extension Blockchain: LosslessStringConvertible {
+    public var description: String {
+        return absoluteString
+    }
+}
+
+extension Blockchain: Codable {
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let absoluteString = try container.decode(String.self)
+        guard let blockchain = Blockchain(absoluteString) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Malformed CAIP-2 chain identifier.")
+        }
+        self = blockchain
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(absoluteString)
     }
 }

--- a/Sources/WalletConnect/Blockchain.swift
+++ b/Sources/WalletConnect/Blockchain.swift
@@ -1,3 +1,21 @@
-//public struct Blockchain {
-//    
-//}
+public struct Blockchain {
+    
+    public let namespace: String
+    
+    public let reference: String
+    
+    public var absoluteString: String {
+        "\(namespace):\(reference)"
+    }
+    
+    public init?(_ string: String) {
+        guard String.conformsToCAIP2(string) else { return nil }
+        let splits = string.split(separator: ":")
+        self.namespace = String(splits[0])
+        self.reference = String(splits[1])
+    }
+    
+    public init?(namespace: String, reference: String) {
+        self.init("\(namespace):\(reference)")
+    }
+}

--- a/Sources/WalletConnect/Blockchain.swift
+++ b/Sources/WalletConnect/Blockchain.swift
@@ -1,0 +1,3 @@
+//public struct Blockchain {
+//    
+//}

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -227,7 +227,7 @@ final class SessionEngine {
         guard let relay = proposal.relays.first else {return}
         let settleParams = SessionType.SettleParams(
             relay: relay,
-            blockchain: Blockchain(chains: proposal.blockchain.chains, accounts: accounts),//TODO
+            blockchain: SessionType.Blockchain(chains: proposal.blockchain.chains, accounts: accounts),//TODO
             permissions: proposal.permissions,
             controller: selfParticipant,
             expiry: Int64(expectedExpiryTimeStamp.timeIntervalSince1970))//todo - test expiration times

--- a/Sources/WalletConnect/Types/Session/SessionProposal.swift
+++ b/Sources/WalletConnect/Types/Session/SessionProposal.swift
@@ -18,9 +18,3 @@ struct SessionProposal: Codable, Equatable {
         return Session.Proposal(proposer: proposer.metadata, permissions: Session.Permissions(permissions: permissions), blockchains: blockchain.chains, proposal: self)
     }
 }
-
-
-struct Blockchain: Codable, Equatable {
-    var chains: Set<String>
-    var accounts: Set<Account>
-}

--- a/Sources/WalletConnect/Types/Session/SessionSequence.swift
+++ b/Sources/WalletConnect/Types/Session/SessionSequence.swift
@@ -14,7 +14,7 @@ struct SessionSequence: ExpirableSequence {
     let relay: RelayProtocolOptions
     let controller: AgreementPeer
     let participants: Participants
-    var blockchain: Blockchain
+    var blockchain: SessionType.Blockchain
     var permissions: SessionPermissions
 
     var acknowledged: Bool
@@ -44,7 +44,7 @@ struct SessionSequence: ExpirableSequence {
         self.expiryDate = Date(timeIntervalSince1970: TimeInterval(settleParams.expiry))
     }
     
-    init(topic: String, relay: RelayProtocolOptions, controller: AgreementPeer, participants: Participants, blockchain: Blockchain, permissions: SessionPermissions, acknowledged: Bool, expiry: Int64) {
+    init(topic: String, relay: RelayProtocolOptions, controller: AgreementPeer, participants: Participants, blockchain: SessionType.Blockchain, permissions: SessionPermissions, acknowledged: Bool, expiry: Int64) {
         self.topic = topic
         self.relay = relay
         self.controller = controller

--- a/Sources/WalletConnect/Types/Session/SessionType.swift
+++ b/Sources/WalletConnect/Types/Session/SessionType.swift
@@ -78,6 +78,11 @@ internal enum SessionType {
     struct ExtendParams: Codable, Equatable {
         let expiry: Int64
     }
+    
+    struct Blockchain: Codable, Equatable {
+        var chains: Set<String>
+        var accounts: Set<Account>
+    }
 }
 
 // A better solution could fit in here

--- a/Tests/WalletConnectTests/AccountTests.swift
+++ b/Tests/WalletConnectTests/AccountTests.swift
@@ -24,9 +24,28 @@ final class AccountTests: XCTestCase {
         XCTAssertNil(Account(chainIdentifier: "std", address: "0"))
     }
     
+    func testInitFromBlockchain() {
+        let chain = Blockchain("std:0")!
+        
+        // Valid accounts
+        XCTAssertNotNil(Account(blockchain: chain, address: "0"))
+        XCTAssertNotNil(Account(blockchain: chain, address: "6d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f7"))
+        
+        // Invalid accounts
+        XCTAssertNil(Account(blockchain: chain, address: ""))
+        XCTAssertNil(Account(blockchain: chain, address: "$"))
+    }
+    
     func testBlockchainIdentifier() {
         let account = Account("eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb")!
         XCTAssertEqual(account.blockchainIdentifier, "eip155:1")
+    }
+    
+    func testBlockchainExtraction() {
+        let account = Account("eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb")!
+        let blockchain = account.blockchain
+        XCTAssertEqual(account.namespace, blockchain.namespace)
+        XCTAssertEqual(account.reference, blockchain.reference)
     }
     
     func testAbsoluteString() {

--- a/Tests/WalletConnectTests/BlockchainTests.swift
+++ b/Tests/WalletConnectTests/BlockchainTests.swift
@@ -30,4 +30,11 @@ final class BlockchainTests: XCTestCase {
         let blockchain = Blockchain(chainString)!
         XCTAssertEqual(blockchain.absoluteString, chainString)
     }
+    
+    func testCodable() throws {
+        let blockchain = Blockchain("chainstd:8c3444cf8970a9e41a706fab93e7a6c4")!
+        let encoded = try JSONEncoder().encode(blockchain)
+        let decoded = try JSONDecoder().decode(Blockchain.self, from: encoded)
+        XCTAssertEqual(blockchain, decoded)
+    }
 }

--- a/Tests/WalletConnectTests/BlockchainTests.swift
+++ b/Tests/WalletConnectTests/BlockchainTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import WalletConnect
+
+final class BlockchainTests: XCTestCase {
+    
+    func testInitFromString() {
+        
+    }
+    
+    func testInitFromNamespaceAndReference() {
+        
+    }
+}

--- a/Tests/WalletConnectTests/BlockchainTests.swift
+++ b/Tests/WalletConnectTests/BlockchainTests.swift
@@ -4,10 +4,30 @@ import XCTest
 final class BlockchainTests: XCTestCase {
     
     func testInitFromString() {
+        // Valid chains
+        XCTAssertNotNil(Blockchain("std:0"))
+        XCTAssertNotNil(Blockchain("chainstd:8c3444cf8970a9e41a706fab93e7a6c4"))
         
+        // Invalid chains
+        XCTAssertNil(Blockchain("st:0"))
+        XCTAssertNil(Blockchain("std:$"))
+        XCTAssertNil(Blockchain("chainstdd:0"))
     }
     
     func testInitFromNamespaceAndReference() {
+        // Valid chains
+        XCTAssertNotNil(Blockchain(namespace: "std", reference: "0"))
+        XCTAssertNotNil(Blockchain(namespace: "chainstd", reference: "8c3444cf8970a9e41a706fab93e7a6c4"))
         
+        // Invalid chains
+        XCTAssertNil(Blockchain(namespace: "st", reference: "0"))
+        XCTAssertNil(Blockchain(namespace: "std", reference: ""))
+        XCTAssertNil(Blockchain(namespace: "std", reference: "8c3444cf8970a9e41a706fab93e7a6c44"))
+    }
+    
+    func testAbsoluteString() {
+        let chainString = "chainstd:8c3444cf8970a9e41a706fab93e7a6c4"
+        let blockchain = Blockchain(chainString)!
+        XCTAssertEqual(blockchain.absoluteString, chainString)
     }
 }

--- a/Tests/WalletConnectTests/Stub/Session+Stub.swift
+++ b/Tests/WalletConnectTests/Stub/Session+Stub.swift
@@ -17,7 +17,7 @@ extension SessionSequence {
                 relay: RelayProtocolOptions.stub(),
                 controller: AgreementPeer(publicKey: controllerKey),
                 participants: Participants(self: Participant.stub(publicKey: selfKey), peer: Participant.stub(publicKey: peerKey)),
-                blockchain: Blockchain.stub(),
+                blockchain: SessionType.Blockchain.stub(),
                 permissions: permissions,
                 acknowledged: acknowledged,
                 expiry: Int64(expiryDate.timeIntervalSince1970))
@@ -32,6 +32,6 @@ extension Account {
 
 extension SessionType.SettleParams {
     static func stub() -> SessionType.SettleParams {
-        return SessionType.SettleParams(relay: RelayProtocolOptions.stub(), blockchain: Blockchain.stub(), permissions: SessionPermissions.stub(), controller: Participant.stub(), expiry: Int64(Date.distantFuture.timeIntervalSince1970))
+        return SessionType.SettleParams(relay: RelayProtocolOptions.stub(), blockchain: SessionType.Blockchain.stub(), permissions: SessionPermissions.stub(), controller: Participant.stub(), expiry: Int64(Date.distantFuture.timeIntervalSince1970))
     }
 }

--- a/Tests/WalletConnectTests/Stub/Stubs.swift
+++ b/Tests/WalletConnectTests/Stub/Stubs.swift
@@ -44,9 +44,9 @@ extension SessionPermissions {
     }
 }
 
-extension Blockchain {
-    static func stub(chains: Set<String> = ["eip155:1"]) -> Blockchain {
-        return Blockchain(chains: chains, accounts: [])
+extension SessionType.Blockchain {
+    static func stub(chains: Set<String> = ["eip155:1"]) -> SessionType.Blockchain {
+        return SessionType.Blockchain(chains: chains, accounts: [])
     }
 }
 


### PR DESCRIPTION
closes #131

Adds the `Blockchain` type conforming to [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md).