### PR TITLE
#143 AnyCodable fix & improvement

### DIFF
--- a/Sources/WalletConnectUtils/AnyCodable.swift
+++ b/Sources/WalletConnectUtils/AnyCodable.swift
@@ -44,7 +44,7 @@ public struct AnyCodable {
             let valueData = try? getDataRepresentation(),
             let string = String(data: valueData, encoding: .utf8)
         else {
-            return "unknown"
+            return ""
         }
         return string
     }
@@ -74,7 +74,9 @@ extension AnyCodable: Equatable {
 extension AnyCodable: CustomStringConvertible {
     
     public var description: String {
-        "AnyCodable: \"\(stringRepresentation)\""
+        let stringSelf = stringRepresentation
+        let description = stringSelf.isEmpty ? "invalid data" : stringSelf
+        return "AnyCodable: \"\(description)\""
     }
 }
 

--- a/Sources/WalletConnectUtils/AnyCodable.swift
+++ b/Sources/WalletConnectUtils/AnyCodable.swift
@@ -32,6 +32,17 @@ public struct AnyCodable {
     }
 }
 
+extension AnyCodable: Equatable {
+    public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+        if let lString = try? lhs.get(String.self),
+           let rString = try? rhs.get(String.self),
+           lString == rString {
+            return true
+        }
+        fatalError("Not implemented")
+    }
+}
+
 extension AnyCodable: Decodable, Encodable {
     
     struct CodingKeys: CodingKey {
@@ -75,10 +86,10 @@ extension AnyCodable: Decodable, Encodable {
             } else if let stringVal = try? container.decode(String.self) {
                 value = stringVal
             } else {
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "the container contains nothing serializable")
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "The container contains nothing serializable.")
             }
         } else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Could not serialize"))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No data found in the decoder."))
         }
     }
     
@@ -109,19 +120,8 @@ extension AnyCodable: Decodable, Encodable {
             } else if let stringVal = value as? String {
                 try container.encode(stringVal)
             } else {
-                throw EncodingError.invalidValue(value, EncodingError.Context.init(codingPath: [], debugDescription: "The value is not encodable"))
+                throw EncodingError.invalidValue(value, EncodingError.Context.init(codingPath: [], debugDescription: "The value is not encodable."))
             }
         }
-    }
-}
-
-extension AnyCodable: Equatable {
-    public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
-        if let lString = try? lhs.get(String.self),
-           let rString = try? rhs.get(String.self),
-           lString == rString {
-            return true
-        }
-        fatalError("Not implemented")
     }
 }

--- a/Tests/TestingUtils/Helpers.swift
+++ b/Tests/TestingUtils/Helpers.swift
@@ -3,6 +3,18 @@ import WalletConnectUtils
 
 public let defaultTimeout: TimeInterval = 5.0
 
+public extension Int {
+    static func random() -> Int {
+        random(in: Int.min...Int.max)
+    }
+}
+
+public extension Double {
+    static func random() -> Double {
+        random(in: 0...1)
+    }
+}
+
 public extension String {
     static func randomTopic() -> String {
         "\(UUID().uuidString)\(UUID().uuidString)".replacingOccurrences(of: "-", with: "").lowercased()

--- a/Tests/WalletConnectTests/AnyCodableTests.swift
+++ b/Tests/WalletConnectTests/AnyCodableTests.swift
@@ -59,28 +59,39 @@ fileprivate let heterogeneousArrayJSON = """
 ]
 """.data(using: .utf8)!
 
-final class AnyCodableTests: XCTestCase {
+// Move this
+extension Int {
+    static func random() -> Int {
+        random(in: Int.min...Int.max)
+    }
+}
 
-//    func testGet() {
-//        do {
-//            let value = AnyCodable(SampleStruct.stub())
-//            _ = try value.get(SampleStruct.self)
-//        } catch {
-//            XCTFail()
-//        }
-//    }
+final class AnyCodableTests: XCTestCase {
     
     func testInitGet() throws {
         XCTAssertNoThrow(try AnyCodable(Int.random(in: Int.min...Int.max)).get(Int.self))
         XCTAssertNoThrow(try AnyCodable(Double.pi).get(Double.self))
         XCTAssertNoThrow(try AnyCodable(Bool.random()).get(Bool.self))
         XCTAssertNoThrow(try AnyCodable(UUID().uuidString).get(String.self))
-//        XCTAssertNoThrow(try AnyCodable((1...10).map { _ in UUID().uuidString }).get([String].self))
-//
-//        XCTAssertNoThrow(try AnyCodable(SampleStruct.stub()).get(SampleStruct.self))
-//
-//        let arr = [AnyCodable(42), AnyCodable(3.14), AnyCodable(true), AnyCodable("string")]
-//        XCTAssertNoThrow(try AnyCodable(arr).get([AnyCodable].self))
+        XCTAssertNoThrow(try AnyCodable((1...10).map { _ in UUID().uuidString }).get([String].self))
+        XCTAssertNoThrow(try AnyCodable(SampleStruct.stub()).get(SampleStruct.self))
+    }
+    
+    func testEqualityInt() {
+        let int = Int.random()
+        let intA = AnyCodable(int)
+        let intB = AnyCodable(int)
+        let intC = AnyCodable(int + 1)
+        XCTAssertEqual(intA, intB)
+        XCTAssertNotEqual(intA, intC)
+        XCTAssertNotEqual(intB, intC)
+    }
+    
+    func testEqualityObject() {
+        let objectA = AnyCodable(SampleStruct.stub())
+        let objectB = AnyCodable(SampleStruct.stub())
+        XCTAssertEqual(objectA, objectA)
+        XCTAssertNotEqual(objectA, objectB)
     }
     
     func testCodingBool() {
@@ -202,7 +213,7 @@ final class AnyCodableTests: XCTestCase {
         XCTAssertThrowsError(try JSONDecoder().decode(AnyCodable.self, from: data)) { error in
             XCTAssert(error is DecodingError)
         }
-        let nullData = " ".data(using: .utf8)!
+        let nullData = "null".data(using: .utf8)!
         XCTAssertThrowsError(try JSONDecoder().decode(AnyCodable.self, from: nullData)) { error in
             XCTAssert(error is DecodingError)
         }

--- a/Tests/WalletConnectTests/Helpers/HelperTypes.swift
+++ b/Tests/WalletConnectTests/Helpers/HelperTypes.swift
@@ -1,0 +1,10 @@
+struct AnyError: Error {}
+
+struct EmptyCodable: Codable {}
+
+struct FailableCodable: Codable {
+    
+    func encode(to encoder: Encoder) throws {
+        throw AnyError()
+    }
+}


### PR DESCRIPTION
closes #143 

Changes how the `AnyCodable` manages its internal representation, fixing a bug where it would fail to get the underlying type right after being instantiated.

Applies full `Equatable` conformance and adds a convenience `stringRepresentation` to help visualize the type on console prints.

Also, improves the public API documentation.