### PR TITLE
#18 Pairing expiry tests

### DIFF
--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -213,8 +213,9 @@ final class PairingEngine {
             // Activate the pairing
             if !pairing.isActive {
                 pairing.activate()
+            } else {
+                try? pairing.extend()
             }
-            try? pairing.extend()
             sequencesStore.setSequence(pairing)
             
             let selfPublicKey = try! AgreementPublicKey(hex: proposal.proposer.publicKey)

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -94,8 +94,7 @@ final class PairingEngine {
         let pairing = PairingSequence(uri: uri)
         let symKey = try! SymmetricKey(hex: uri.symKey) // FIXME: Malformed QR code from external source can crash the SDK
         try! kms.setSymmetricKey(symKey, for: pairing.topic)
-//        pairing.activate()
-//        try? pairing.extend()
+        pairing.activate()
         wcSubscriber.setSubscription(topic: pairing.topic)
         sequencesStore.setSequence(pairing)
     }

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -91,7 +91,7 @@ final class PairingEngine {
         guard !hasPairing(for: uri.topic) else {
             throw WalletConnectError.pairingAlreadyExist
         }
-        let pairing = PairingSequence(uri: uri)
+        var pairing = PairingSequence(uri: uri)
         let symKey = try! SymmetricKey(hex: uri.symKey) // FIXME: Malformed QR code from external source can crash the SDK
         try! kms.setSymmetricKey(symKey, for: pairing.topic)
         pairing.activate()

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -93,8 +93,10 @@ final class PairingEngine {
             throw WalletConnectError.pairingAlreadyExist
         }
         let pairing = PairingSequence.createFromURI(uri)
-        let symKey = try! SymmetricKey(hex: uri.symKey)
+        let symKey = try! SymmetricKey(hex: uri.symKey) // FIXME: Malformed QR code from external source can crash the SDK
         try! kms.setSymmetricKey(symKey, for: pairing.topic)
+//        pairing.activate()
+//        try? pairing.extend()
         wcSubscriber.setSubscription(topic: pairing.topic)
         sequencesStore.setSequence(pairing)
     }

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -63,7 +63,7 @@ final class PairingEngine {
     func create() -> WalletConnectURI? {
         let topic = topicInitializer()
         let symKey = try! kms.createSymmetricKey(topic)
-        let pairing = PairingSequence.build(topic, selfMetadata: metadata)
+        let pairing = PairingSequence(topic: topic, selfMetadata: metadata)
         let uri = WalletConnectURI(topic: topic, symKey: symKey.hexRepresentation, relay: pairing.relay)
         sequencesStore.setSequence(pairing)
         wcSubscriber.setSubscription(topic: topic)
@@ -92,7 +92,7 @@ final class PairingEngine {
         guard !hasPairing(for: uri.topic) else {
             throw WalletConnectError.pairingAlreadyExist
         }
-        let pairing = PairingSequence.createFromURI(uri)
+        let pairing = PairingSequence(uri: uri)
         let symKey = try! SymmetricKey(hex: uri.symKey) // FIXME: Malformed QR code from external source can crash the SDK
         try! kms.setSymmetricKey(symKey, for: pairing.topic)
 //        pairing.activate()

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -5,7 +5,6 @@ import WalletConnectKMS
 
 
 final class PairingEngine {
-    var onPairingExtend: ((Pairing)->())?
     var onSessionProposal: ((Session.Proposal)->())?
     var onProposeResponse: ((String)->())?
     var onSessionRejected: ((Session.Proposal, SessionType.Reason)->())?
@@ -214,8 +213,9 @@ final class PairingEngine {
             if !pairing.isActive {
                 pairing.activate()
             } else {
-                try? pairing.extend()
+                try? pairing.updateExpiry()
             }
+            
             sequencesStore.setSequence(pairing)
             
             let selfPublicKey = try! AgreementPublicKey(hex: proposal.proposer.publicKey)

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -10,7 +10,7 @@ final class SessionEngine {
     var onSessionSettle: ((Session)->())?
     var onSessionRejected: ((String, SessionType.Reason)->())?
     var onSessionUpdateAccounts: ((String, Set<Account>)->())?
-    var onSessionExtended: ((Session) -> ())?
+    var onSessionExpiry: ((Session) -> ())?
     var onSessionDelete: ((String, SessionType.Reason)->())?
     var onEventReceived: ((String, Session.Event)->())?
     
@@ -84,7 +84,7 @@ final class SessionEngine {
         }
     }
      
-    func extend(topic: String, by ttl: Int64) throws {
+    func updateExpiry(topic: String, by ttl: Int64) throws {
         guard var session = sequencesStore.getSequence(forTopic: topic) else {
             throw WalletConnectError.noSessionMatchingTopic(topic)
         }
@@ -94,7 +94,7 @@ final class SessionEngine {
         guard session.selfIsController else {
             throw WalletConnectError.unauthorizedNonControllerCall
         }
-        try session.extend(by: ttl)
+        try session.updateExpiry(by: ttl)
         let newExpiry = Int64(session.expiryDate.timeIntervalSince1970 )
         sequencesStore.setSequence(session)
         relayer.request(.wcSessionUpdateExpiry(SessionType.UpdateExpiryParams(expiry: newExpiry)), onTopic: topic)
@@ -185,10 +185,10 @@ final class SessionEngine {
                 wcSessionRequest(subscriptionPayload, payloadParams: sessionRequestParams)
             case .sessionPing(_):
                 wcSessionPing(subscriptionPayload)
-            case .sessionUpdateExpiry(let extendParams):
-                wcSessionExtend(subscriptionPayload, extendParams: extendParams)
-            case .sessionEvent(let notificationParams):
-                wcSessionNotification(subscriptionPayload, notificationParams: notificationParams)
+            case .sessionUpdateExpiry(let updateExpiryParams):
+                wcSessionUpdateExpiry(subscriptionPayload, updateExpiryParams: updateExpiryParams)
+            case .sessionEvent(let eventParams):
+                wcSessionNotification(subscriptionPayload, notificationParams: eventParams)
             default:
                 logger.warn("Warning: Session Engine - Unexpected method type: \(subscriptionPayload.wcRequest.method) received from subscriber")
             }
@@ -252,7 +252,7 @@ final class SessionEngine {
                   return
               }
         guard session.peerIsController else {
-            relayer.respondError(for: payload, reason: .unauthorizedUpdateRequest(context: .session))
+            relayer.respondError(for: payload, reason: .unauthorizedUpdateAccountRequest)
             return
         }
         session.updateAccounts(updateParams.accounts)
@@ -261,25 +261,25 @@ final class SessionEngine {
         onSessionUpdateAccounts?(topic, updateParams.accounts)
     }
     
-    private func wcSessionExtend(_ payload: WCRequestSubscriptionPayload, extendParams: SessionType.UpdateExpiryParams) {
+    private func wcSessionUpdateExpiry(_ payload: WCRequestSubscriptionPayload, updateExpiryParams: SessionType.UpdateExpiryParams) {
         let topic = payload.topic
         guard var session = sequencesStore.getSequence(forTopic: topic) else {
             relayer.respondError(for: payload, reason: .noContextWithTopic(context: .session, topic: topic))
             return
         }
         guard session.peerIsController else {
-            relayer.respondError(for: payload, reason: .unauthorizedExtendRequest(context: .session))
+            relayer.respondError(for: payload, reason: .unauthorizedUpdateExpiryRequest)
             return
         }
         do {
-            try session.extend(to: extendParams.expiry)
+            try session.updateExpiry(to: updateExpiryParams.expiry)
         } catch {
-            relayer.respondError(for: payload, reason: .invalidExtendRequest(context: .session))
+            relayer.respondError(for: payload, reason: .invalidUpdateExpiryRequest)
             return
         }
         sequencesStore.setSequence(session)
         relayer.respondSuccess(for: payload)
-        onSessionExtended?(session.publicRepresentation())
+        onSessionExpiry?(session.publicRepresentation())
     }
     
     private func wcSessionDelete(_ payload: WCRequestSubscriptionPayload, deleteParams: SessionType.DeleteParams) {
@@ -347,7 +347,7 @@ final class SessionEngine {
             return
         } else {
             guard session.events.contains(params.type) else {
-                throw WalletConnectError.invalidNotificationType
+                throw WalletConnectError.invalidEventType
             }
         }
     }
@@ -410,25 +410,4 @@ final class SessionEngine {
             logger.error("Peer failed to update state.")
         }
     }
-    
-//    private func validatePermissions(_ permissions: SessionPermissions) -> Bool {
-////        for chainId in permissions.blockchain.chains {
-////            if !String.conformsToCAIP2(chainId) {
-////                return false
-////            }
-////        }
-//        for method in permissions.jsonrpc.methods {
-//            if method.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-//                return false
-//            }
-//        }
-//        if let notificationTypes = permissions.notifications?.types {
-//            for notification in notificationTypes {
-//                if notification.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-//                    return false
-//                }
-//            }
-//        }
-//        return true
-//    }
 }

--- a/Sources/WalletConnect/Engine/SessionStateMachines/ControllerSessionStateMachine.swift
+++ b/Sources/WalletConnect/Engine/SessionStateMachines/ControllerSessionStateMachine.swift
@@ -7,7 +7,8 @@ import Combine
 final class ControllerSessionStateMachine: SessionStateMachineValidating {
     
     var onMethodsUpdate: ((String, Set<String>)->())?
-    
+    var onEventsUpdate: ((String, Set<String>)->())?
+
     private let sequencesStore: SessionSequenceStorage
     private let relayer: WalletConnectRelaying
     private let kms: KeyManagementServiceProtocol
@@ -40,10 +41,29 @@ final class ControllerSessionStateMachine: SessionStateMachineValidating {
         guard validateMethods(methods) else {
             throw WalletConnectError.invalidMethod
         }
-        logger.debug("controller will update methods")
+        logger.debug("Controller will update methods")
         session.updateMethods(methods)
         sequencesStore.setSequence(session)
         relayer.request(.wcSessionUpdateMethods(SessionType.UpdateMethodsParams(methods: methods)), onTopic: topic)
+    }
+    
+    func updateEvents(topic: String, events: Set<String>) throws {
+        guard var session = sequencesStore.getSequence(forTopic: topic) else {
+            throw WalletConnectError.noSessionMatchingTopic(topic)
+        }
+        guard session.acknowledged else {
+            throw WalletConnectError.sessionNotAcknowledged(topic)
+        }
+        guard session.selfIsController else {
+            throw WalletConnectError.unauthorizedNonControllerCall
+        }
+        guard validateEvents(events) else {
+            throw WalletConnectError.invalidEventType
+        }
+        logger.debug("Controller will update events")
+        session.updateEvents(events)
+        sequencesStore.setSequence(session)
+        relayer.request(.wcSessionUpdateEvents(SessionType.UpdateEventsParams(events: events)), onTopic: topic)
     }
     
     // MARK: - Handle Response
@@ -52,6 +72,8 @@ final class ControllerSessionStateMachine: SessionStateMachineValidating {
         switch response.requestParams {
         case .sessionUpdateMethods:
             handleUpdateMethodsResponse(topic: response.topic, result: response.result)
+        case .sessionUpdateEvents:
+            handleUpdateEventsResponse(topic: response.topic, result: response.result)
         default:
             break
         }
@@ -68,6 +90,20 @@ final class ControllerSessionStateMachine: SessionStateMachineValidating {
         case .error:
             //TODO - state sync
             logger.error("Peer failed to update methods.")
+        }
+    }
+    
+    private func handleUpdateEventsResponse(topic: String, result: JsonRpcResult) {
+        guard let session = sequencesStore.getSequence(forTopic: topic) else {
+            return
+        }
+        switch result {
+        case .response:
+            //TODO - state sync
+            onEventsUpdate?(session.topic, session.methods)
+        case .error:
+            //TODO - state sync
+            logger.error("Peer failed to update events.")
         }
     }
 }

--- a/Sources/WalletConnect/Engine/SessionStateMachines/NonControllerSessionStateMachine.swift
+++ b/Sources/WalletConnect/Engine/SessionStateMachines/NonControllerSessionStateMachine.swift
@@ -46,7 +46,7 @@ final class NonControllerSessionStateMachine: SessionStateMachineValidating {
             return
         }
         guard session.peerIsController else {
-            relayer.respondError(for: payload, reason: .unauthorizedUpdateRequest(context: .session))
+            relayer.respondError(for: payload, reason: .unauthorizedUpdateMethodsRequest)
             return
         }
         session.updateMethods(updateParams.methods)

--- a/Sources/WalletConnect/Engine/SessionStateMachines/SessionStateMachineValidating.swift
+++ b/Sources/WalletConnect/Engine/SessionStateMachines/SessionStateMachineValidating.swift
@@ -3,12 +3,22 @@ import Foundation
 
 protocol SessionStateMachineValidating {
     func validateMethods(_ methods: Set<String>) -> Bool
+    func validateEvents(_ events: Set<String>) -> Bool
 }
 
 extension SessionStateMachineValidating {
     func validateMethods(_ methods: Set<String>) -> Bool {
         for method in methods {
             if method.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return false
+            }
+        }
+        return true
+    }
+    
+    func validateEvents(_ events: Set<String>) -> Bool {
+        for event in events {
+            if event.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 return false
             }
         }

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -57,10 +57,10 @@ struct PairingSequence: ExpirableSequence {
         isActive = true
     }
     
-    mutating func extend(_ ttl: Int = Int(PairingSequence.timeToLiveActive)) throws {
-//        let now = Date()
-        let newExpiryDate = Date(timeIntervalSinceNow: TimeInterval(ttl))
-        let maxExpiryDate = Date(timeIntervalSinceNow: TimeInterval(PairingSequence.timeToLiveActive))
+    mutating func extend(_ ttl: TimeInterval = PairingSequence.timeToLiveActive) throws {
+        let now = Self.dateInitializer()
+        let newExpiryDate = now.advanced(by: ttl)
+        let maxExpiryDate = now.advanced(by: Self.timeToLiveActive)
         guard newExpiryDate > expiryDate && newExpiryDate <= maxExpiryDate else {
             throw WalletConnectError.invalidExtendTime
         }

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -2,17 +2,13 @@ import Foundation
 import WalletConnectKMS
 
 struct PairingSequence: ExpirableSequence {
-    struct Participants: Codable, Equatable {
-        var `self`: AppMetadata?
-        var peer: AppMetadata?
-    }    
-    let topic: String
-    let relay: RelayProtocolOptions
-    var participants: Participants
-    private (set) var isActive: Bool = false
     
-    private (set) var expiryDate: Date
-
+    #if DEBUG
+    static var dateInitializer: () -> Date = Date.init
+    #else
+    private static var dateInitializer: () -> Date = Date.init
+    #endif
+    
     static var timeToLiveInactive: Int {
         5 * Time.minute
     }
@@ -21,11 +17,24 @@ struct PairingSequence: ExpirableSequence {
         Time.day * 30
     }
     
+    struct Participants: Codable, Equatable {
+        var `self`: AppMetadata?
+        var peer: AppMetadata?
+    }
+    
+    let topic: String
+    let relay: RelayProtocolOptions
+    var participants: Participants
+    
+    private (set) var isActive: Bool = false
+    private (set) var expiryDate: Date
+    
     mutating func activate() {
         isActive = true
     }
     
     mutating func extend(_ ttl: Int = PairingSequence.timeToLiveActive) throws {
+//        let now = Date()
         let newExpiryDate = Date(timeIntervalSinceNow: TimeInterval(ttl))
         let maxExpiryDate = Date(timeIntervalSinceNow: TimeInterval(PairingSequence.timeToLiveActive))
         guard newExpiryDate > expiryDate && newExpiryDate <= maxExpiryDate else {
@@ -35,6 +44,7 @@ struct PairingSequence: ExpirableSequence {
     }
     
     static func build(_ topic: String, selfMetadata: AppMetadata) -> PairingSequence {
+        let now = dateInitializer()
         let relay = RelayProtocolOptions(protocol: "waku", data: nil)
         return PairingSequence(
             topic: topic,
@@ -42,7 +52,8 @@ struct PairingSequence: ExpirableSequence {
             participants: Participants(
                 self: selfMetadata,
                 peer: nil),
-            expiryDate: Date(timeIntervalSinceNow: TimeInterval(timeToLiveInactive)))
+//            expiryDate: Date(timeIntervalSinceNow: TimeInterval(timeToLiveInactive)))
+            expiryDate: now.advanced(by: TimeInterval(timeToLiveInactive)))
     }
     
     static func createFromURI(_ uri: WalletConnectURI) -> PairingSequence {

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -9,12 +9,12 @@ struct PairingSequence: ExpirableSequence {
     private static var dateInitializer: () -> Date = Date.init
     #endif
     
-    static var timeToLiveInactive: Int {
-        5 * Time.minute
+    static var timeToLiveInactive: TimeInterval {
+        5 * .minute
     }
     
-    static var timeToLiveActive: Int {
-        Time.day * 30
+    static var timeToLiveActive: TimeInterval {
+        30 * .day 
     }
     
     struct Participants: Codable, Equatable {
@@ -33,7 +33,7 @@ struct PairingSequence: ExpirableSequence {
         isActive = true
     }
     
-    mutating func extend(_ ttl: Int = PairingSequence.timeToLiveActive) throws {
+    mutating func extend(_ ttl: Int = Int(PairingSequence.timeToLiveActive)) throws {
 //        let now = Date()
         let newExpiryDate = Date(timeIntervalSinceNow: TimeInterval(ttl))
         let maxExpiryDate = Date(timeIntervalSinceNow: TimeInterval(PairingSequence.timeToLiveActive))
@@ -44,7 +44,6 @@ struct PairingSequence: ExpirableSequence {
     }
     
     static func build(_ topic: String, selfMetadata: AppMetadata) -> PairingSequence {
-        let now = dateInitializer()
         let relay = RelayProtocolOptions(protocol: "waku", data: nil)
         return PairingSequence(
             topic: topic,
@@ -52,8 +51,7 @@ struct PairingSequence: ExpirableSequence {
             participants: Participants(
                 self: selfMetadata,
                 peer: nil),
-//            expiryDate: Date(timeIntervalSinceNow: TimeInterval(timeToLiveInactive)))
-            expiryDate: now.advanced(by: TimeInterval(timeToLiveInactive)))
+            expiryDate: dateInitializer().advanced(by: timeToLiveInactive))
     }
     
     static func createFromURI(_ uri: WalletConnectURI) -> PairingSequence {
@@ -63,6 +61,6 @@ struct PairingSequence: ExpirableSequence {
             participants: Participants(
                 self: nil,
                 peer: nil),
-            expiryDate: Date(timeIntervalSinceNow: TimeInterval(timeToLiveActive)))
+            expiryDate: dateInitializer().advanced(by: timeToLiveInactive))
     }
 }

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -55,15 +55,15 @@ struct PairingSequence: ExpirableSequence {
     
     mutating func activate() {
         isActive = true
-        try? extend()
+        try? updateExpiry()
     }
     
-    mutating func extend(_ ttl: TimeInterval = PairingSequence.timeToLiveActive) throws {
+    mutating func updateExpiry(_ ttl: TimeInterval = PairingSequence.timeToLiveActive) throws {
         let now = Self.dateInitializer()
         let newExpiryDate = now.advanced(by: ttl)
         let maxExpiryDate = now.advanced(by: Self.timeToLiveActive)
         guard newExpiryDate > expiryDate && newExpiryDate <= maxExpiryDate else {
-            throw WalletConnectError.invalidExtendTime
+            throw WalletConnectError.invalidUpdateExpiryValue
         }
         expiryDate = newExpiryDate
     }

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -55,6 +55,7 @@ struct PairingSequence: ExpirableSequence {
     
     mutating func activate() {
         isActive = true
+        try? extend()
     }
     
     mutating func extend(_ ttl: TimeInterval = PairingSequence.timeToLiveActive) throws {

--- a/Sources/WalletConnect/Types/Pairing/PairingType.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingType.swift
@@ -14,8 +14,4 @@ internal enum PairingType {
     }
     
     struct PingParams: Codable, Equatable {}
-    
-    struct ExtendParams: Codable, Equatable {
-        let ttl: Int
-    }
 }

--- a/Sources/WalletConnect/Types/ReasonCode.swift
+++ b/Sources/WalletConnect/Types/ReasonCode.swift
@@ -15,15 +15,17 @@ enum ReasonCode {
 
     
     case invalidUpdateMethodsRequest
-    case invalidExtendRequest(context: Context)
+    case invalidUpdateExpiryRequest
     case noContextWithTopic(context: Context, topic: String)
     
     // 3000 (Unauthorized)
     case unauthorizedTargetChain(String)
     case unauthorizedRPCMethod(String)
     case unauthorizedEventType(String)
-    case unauthorizedUpdateRequest(context: Context)
-    case unauthorizedExtendRequest(context: Context)
+    case unauthorizedUpdateAccountRequest
+    case unauthorizedUpdateMethodsRequest
+    case unauthorizedUpdateEventsRequest
+    case unauthorizedUpdateExpiryRequest
     case unauthorizedMatchingController(isController: Bool)
     
     // 5000
@@ -38,15 +40,21 @@ enum ReasonCode {
         case .invalidUpdateAccountsRequest: return 1003
             
         case .invalidUpdateMethodsRequest: return 1004
-        case .invalidExtendRequest: return 1005
+        case .invalidUpdateExpiryRequest: return 1005
         case .noContextWithTopic: return 1301
+            
+            
         case .unauthorizedTargetChain: return 3000
         case .unauthorizedRPCMethod: return 3001
         case .unauthorizedEventType: return 3002
             
             
-        case .unauthorizedUpdateRequest: return 3003
-        case .unauthorizedExtendRequest: return 3005
+        case .unauthorizedUpdateAccountRequest: return 3003
+            
+            
+        case .unauthorizedUpdateMethodsRequest: return 3004
+        case .unauthorizedUpdateEventsRequest: return 3005
+        case .unauthorizedUpdateExpiryRequest: return 3005
         case .unauthorizedMatchingController: return 3100
         case .disapprovedChains: return 5000
         case .disapprovedMethods: return 5001
@@ -64,8 +72,8 @@ enum ReasonCode {
             return "Invalid update accounts request"
         case .invalidUpdateMethodsRequest:
             return "Invalid update methods request"
-        case .invalidExtendRequest(context: let context):
-            return "Invalid \(context) extend request"
+        case .invalidUpdateExpiryRequest:
+            return "Invalid update expiry request"
         case .noContextWithTopic(let context, let topic):
             return "No matching \(context) with topic: \(topic)"
         case .unauthorizedTargetChain(let chainId):
@@ -74,12 +82,16 @@ enum ReasonCode {
             return "Unauthorized JSON-RPC method requested: \(method)"
         case .unauthorizedEventType(let type):
             return "Unauthorized notification type requested: \(type)"
-        case .unauthorizedUpdateRequest(let context):
-            return "Unauthorized \(context) update request"
+        case .unauthorizedUpdateAccountRequest:
+            return "Unauthorized update accounts request"
+        case .unauthorizedUpdateMethodsRequest:
+            return "Unauthorized update methods request"
+        case .unauthorizedUpdateEventsRequest:
+            return "Unauthorized update events request"
+        case .unauthorizedUpdateExpiryRequest:
+            return "Unauthorized update expiry request"
         case .unauthorizedMatchingController(let isController):
             return "Unauthorized: peer is also \(isController ? "" : "non-")controller"
-        case .unauthorizedExtendRequest(context: let context):
-            return "Unauthorized \(context) extend request"
         case .disapprovedChains:
             return "User disapproved requested chains"
         case .disapprovedMethods:

--- a/Sources/WalletConnect/Types/Session/SessionSequence.swift
+++ b/Sources/WalletConnect/Types/Session/SessionSequence.swift
@@ -110,24 +110,24 @@ struct SessionSequence: ExpirableSequence {
         self.events = events
     }
     
-    /// extends session by givien ttl
-    /// - Parameter ttl: time the session should be extended by - in seconds
-    mutating func extend(by ttl: Int64) throws {
+    /// updates session expiry by given ttl
+    /// - Parameter ttl: time the session expiry should be updated by - in seconds
+    mutating func updateExpiry(by ttl: Int64) throws {
         let newExpiryDate = Date(timeIntervalSinceNow: TimeInterval(ttl))
         let maxExpiryDate = Date(timeIntervalSinceNow: TimeInterval(SessionSequence.defaultTimeToLive))
         guard newExpiryDate > expiryDate && newExpiryDate <= maxExpiryDate else {
-            throw WalletConnectError.invalidExtendTime
+            throw WalletConnectError.invalidUpdateExpiryValue
         }
         expiryDate = newExpiryDate
     }
     
-    /// extends session expiry to given timestamp
+    /// updates session expiry to given timestamp
     /// - Parameter expiry: timestamp in the future in seconds
-    mutating func extend(to expiry: Int64) throws {
+    mutating func updateExpiry(to expiry: Int64) throws {
         let newExpiryDate = Date(timeIntervalSince1970: TimeInterval(expiry))
         let maxExpiryDate = Date(timeIntervalSinceNow: TimeInterval(SessionSequence.defaultTimeToLive))
         guard newExpiryDate > expiryDate && newExpiryDate <= maxExpiryDate else {
-            throw WalletConnectError.invalidExtendTime
+            throw WalletConnectError.invalidUpdateExpiryValue
         }
         expiryDate = newExpiryDate
     }

--- a/Sources/WalletConnect/Types/WCMethod.swift
+++ b/Sources/WalletConnect/Types/WCMethod.swift
@@ -25,16 +25,16 @@ enum WCMethod {
             return WCRequest(method: .sessionUpdateMethods, params: .sessionUpdateMethods(updateParams))
         case .wcSessionUpdateEvents(let updateParams):
             return WCRequest(method: .sessionUpdateEvents, params: .sessionUpdateEvents(updateParams))
-        case .wcSessionUpdateExpiry(let extendParams):
-            return WCRequest(method: .sessionUpdateExpiry, params: .sessionUpdateExpiry(extendParams))
+        case .wcSessionUpdateExpiry(let updateExpiryParams):
+            return WCRequest(method: .sessionUpdateExpiry, params: .sessionUpdateExpiry(updateExpiryParams))
         case .wcSessionDelete(let deleteParams):
             return WCRequest(method: .sessionDelete, params: .sessionDelete(deleteParams))
         case .wcSessionRequest(let payloadParams):
             return WCRequest(method: .sessionRequest, params: .sessionRequest(payloadParams))
         case .wcSessionPing:
             return WCRequest(method: .sessionPing, params: .sessionPing(SessionType.PingParams()))
-        case .wcSessionEvent(let notificationParams):
-            return WCRequest(method: .sessionEvent, params: .sessionEvent(notificationParams))
+        case .wcSessionEvent(let eventParams):
+            return WCRequest(method: .sessionEvent, params: .sessionEvent(eventParams))
         }
     }
 }

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -190,13 +190,13 @@ public final class WalletConnectClient {
         try controllerSessionStateMachine.updateMethods(topic: topic, methods: methods)
     }
     
-    /// For controller to extend a session lifetime
+    /// For controller to update expiry of a session
     /// - Parameters:
     ///   - topic: Topic of the Session, it can be a pairing or a session topic.
     ///   - ttl: Time in seconds that a target session is expected to be extended for. Must be greater than current time to expire and than 7 days
-    public func extend(topic: String, ttl: Int64 = Session.defaultTimeToLive) throws {
+    public func updateExpiry(topic: String, ttl: Int64 = Session.defaultTimeToLive) throws {
         if sessionEngine.hasSession(for: topic) {
-            try sessionEngine.extend(topic: topic, by: ttl)
+            try sessionEngine.updateExpiry(topic: topic, by: ttl)
         }
     }
     
@@ -303,9 +303,6 @@ public final class WalletConnectClient {
     // MARK: - Private
     
     private func setUpEnginesCallbacks() {
-        pairingEngine.onPairingExtend = { [unowned self] pairing in
-            delegate?.didExtend(pairing: pairing)
-        }
         sessionEngine.onSessionSettle = { [unowned self] settledSession in
             delegate?.didSettle(session: settledSession)
         }
@@ -330,8 +327,8 @@ public final class WalletConnectClient {
         sessionEngine.onSessionUpdateAccounts = { [unowned self] topic, accounts in
             delegate?.didUpdate(sessionTopic: topic, accounts: accounts)
         }
-        sessionEngine.onSessionExtended = { [unowned self] session in
-            delegate?.didExtend(session: session)
+        sessionEngine.onSessionExpiry = { [unowned self] session in
+            delegate?.didUpdateExpiry(session: session)
         }
         sessionEngine.onEventReceived = { [unowned self] topic, notification in
             delegate?.didReceive(notification: notification, sessionTopic: topic)

--- a/Sources/WalletConnect/WalletConnectClientDelegate.swift
+++ b/Sources/WalletConnect/WalletConnectClientDelegate.swift
@@ -51,24 +51,18 @@ public protocol WalletConnectClientDelegate: AnyObject {
     /// Function will be executed on proposer client only.
     func didReject(proposal: Session.Proposal, reason: Reason)
     
-    /// Tells the delegate that peer has extended pairing lifetime.
+    /// Tells the delegate that session expiry has been updated
     ///
     /// Function will be executed on non-controller client only.
-    func didExtend(pairing: Pairing)
-    
-    /// Tells the delegate that peer has extended session lifetime.
-    ///
-    /// Function will be executed on non-controller client only.
-    func didExtend(session: Session)
+    func didUpdateExpiry(session: Session)
 }
 
 public extension WalletConnectClientDelegate {
     func didReceive(notification: Session.Event, sessionTopic: String) {}
     func didReject(proposal: String, reason: Reason) {}
-    func didExtend(pairing: Pairing) {}
     func didReceive(sessionRequest: Request) {}
     func didReceive(sessionProposal: Session.Proposal) {}
     func didReceive(sessionResponse: Response) {}
-    func didExtend(session: Session) {}
+    func didUpdateExpiry(session: Session) {}
     func didReject(proposal: Session.Proposal, reason: Reason) {}
 }

--- a/Sources/WalletConnect/WalletConnectError.swift
+++ b/Sources/WalletConnect/WalletConnectError.swift
@@ -7,8 +7,8 @@ enum WalletConnectError: Error {
     case sessionNotAcknowledged(String)
     case pairingNotSettled(String)
     case invalidMethod
-    case invalidNotificationType
-    case invalidExtendTime
+    case invalidEventType
+    case invalidUpdateExpiryValue
     case unauthorizedNonControllerCall
     case pairingAlreadyExist
     case topicGenerationFailed
@@ -37,11 +37,11 @@ extension WalletConnectError {
             return "Session is not settled on topic \(topic)."
         case .pairingNotSettled(let topic):
             return "Pairing is not settled on topic \(topic)."
-        case .invalidExtendTime:
-            return "Extend time is out of expected range"
+        case .invalidUpdateExpiryValue:
+            return "Update expiry time is out of expected range"
         case .invalidMethod:
             return "Methods set is invalid."
-        case .invalidNotificationType:
+        case .invalidEventType:
             return "Invalid notification type."
         case .unauthorizedNonControllerCall:
             return "Method must be called by a controller client."

--- a/Sources/WalletConnectKMS/Crypto/KeyManagementService.swift
+++ b/Sources/WalletConnectKMS/Crypto/KeyManagementService.swift
@@ -119,8 +119,6 @@ public class KeyManagementService: KeyManagementServiceProtocol {
             print("Key Agreement Error: Private key not found for public key: \(selfPublicKey.hexRepresentation)")
             throw KeyManagementService.Error.keyNotFound
         }
-        
-        
         return try KeyManagementService.generateAgreementKey(from: privateKey, peerPublicKey: hexRepresentation)
     }
     

--- a/Sources/WalletConnectUtils/TimeInterval+Extension.swift
+++ b/Sources/WalletConnectUtils/TimeInterval+Extension.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public extension TimeInterval {
+    
+    static var day: TimeInterval {
+        24 * .hour
+    }
+    
+    static var hour: TimeInterval {
+        60 * .minute
+    }
+    
+    static var minute: TimeInterval {
+        60
+    }
+}

--- a/Tests/WalletConnectTests/ControllerSessionStateMachineTests.swift
+++ b/Tests/WalletConnectTests/ControllerSessionStateMachineTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import WalletConnectUtils
+@testable import TestingUtils
+import WalletConnectKMS
+@testable import WalletConnect
+
+
+class ControllerSessionStateMachineTests: XCTestCase {
+    var sut: ControllerSessionStateMachine!
+    var relayMock: MockedWCRelay!
+    var storageMock: SessionSequenceStorageMock!
+    var cryptoMock: KeyManagementServiceMock!
+    
+    override func setUp() {
+        relayMock = MockedWCRelay()
+        storageMock = SessionSequenceStorageMock()
+        cryptoMock = KeyManagementServiceMock()
+        sut = ControllerSessionStateMachine(relay: relayMock, kms: cryptoMock, sequencesStore: storageMock, logger: ConsoleLoggerMock())
+    }
+    
+    override func tearDown() {
+        relayMock = nil
+        storageMock = nil
+        cryptoMock = nil
+        sut = nil
+    }
+    
+    // MARK: - Update Methods
+        
+    func testUpdateMethodsSuccess() throws {
+        let session = SessionSequence.stub(isSelfController: true)
+        storageMock.setSequence(session)
+        let methodsToUpdate: Set<String> = ["m1", "m2"]
+        try sut.updateMethods(topic: session.topic, methods: methodsToUpdate)
+        let updatedSession = storageMock.getSequence(forTopic: session.topic)
+        XCTAssertTrue(relayMock.didCallRequest)
+        XCTAssertEqual(methodsToUpdate, updatedSession?.methods)
+    }
+    
+    func testUpdateMethodsErrorSessionNotFound() {
+        XCTAssertThrowsError(try sut.updateMethods(topic: "", methods: ["m1"])) { error in
+            XCTAssertTrue(error.isNoSessionMatchingTopicError)
+        }
+    }
+    
+    func testUpdateMethodsErrorSessionNotAcknowledged() {
+        let session = SessionSequence.stub(acknowledged: false)
+        storageMock.setSequence(session)
+        XCTAssertThrowsError(try sut.updateMethods(topic: session.topic, methods: ["m1"])) { error in
+            XCTAssertTrue(error.isSessionNotAcknowledgedError)
+        }
+    }
+
+    func testUpdateMethodsErrorInvalidMethod() {
+        let session = SessionSequence.stub(isSelfController: true)
+        storageMock.setSequence(session)
+        XCTAssertThrowsError(try sut.updateMethods(topic: session.topic, methods: [""])) { error in
+            XCTAssertTrue(error.isInvalidMetodError)
+        }
+    }
+
+    func testUpdateMethodsErrorCalledByNonController() {
+        let session = SessionSequence.stub(isSelfController: false)
+        storageMock.setSequence(session)
+        XCTAssertThrowsError(try sut.updateMethods(topic: session.topic, methods: ["m1"])) { error in
+            XCTAssertTrue(error.isUnauthorizedNonControllerCallError)
+        }
+    }
+}

--- a/Tests/WalletConnectTests/Helpers/Error+Extension.swift
+++ b/Tests/WalletConnectTests/Helpers/Error+Extension.swift
@@ -19,15 +19,15 @@ extension Error {
         return true
     }
     
-    var isSessionNotSettledError: Bool {
+    var isSessionNotAcknowledgedError: Bool {
         guard case .sessionNotAcknowledged = wcError else { return false }
         return true
     }
     
-//    var isInvalidPermissionsError: Bool {
-//        guard case .invalidPermissions = wcError else { return false }
-//        return true
-//    }
+    var isInvalidMetodError: Bool {
+        guard case .invalidMethod = wcError else { return false }
+        return true
+    }
     
     var isUnauthorizedNonControllerCallError: Bool {
         guard case .unauthorizedNonControllerCall = wcError else { return false }

--- a/Tests/WalletConnectTests/Mocks/MockedRelay.swift
+++ b/Tests/WalletConnectTests/Mocks/MockedRelay.swift
@@ -6,7 +6,7 @@ import WalletConnectUtils
 @testable import TestingUtils
 
 class MockedWCRelay: WalletConnectRelaying {
-    private let responsePublisherSubject = PassthroughSubject<WCResponse, Never>()
+    let responsePublisherSubject = PassthroughSubject<WCResponse, Never>()
 
     var responsePublisher: AnyPublisher<WCResponse, Never> {
         responsePublisherSubject.eraseToAnyPublisher()
@@ -22,7 +22,7 @@ class MockedWCRelay: WalletConnectRelaying {
     }
     private let transportConnectionPublisherSubject = PassthroughSubject<Void, Never>()
     
-    private let wcRequestPublisherSubject = PassthroughSubject<WCRequestSubscriptionPayload, Never>()
+    let wcRequestPublisherSubject = PassthroughSubject<WCRequestSubscriptionPayload, Never>()
     var wcRequestPublisher: AnyPublisher<WCRequestSubscriptionPayload, Never> {
         wcRequestPublisherSubject.eraseToAnyPublisher()
     }

--- a/Tests/WalletConnectTests/NonControllerSessionStateMachineTests.swift
+++ b/Tests/WalletConnectTests/NonControllerSessionStateMachineTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import WalletConnectUtils
+@testable import TestingUtils
+import WalletConnectKMS
+@testable import WalletConnect
+
+
+class NonControllerSessionStateMachineTests: XCTestCase {
+    var sut: NonControllerSessionStateMachine!
+    var relayMock: MockedWCRelay!
+    var storageMock: SessionSequenceStorageMock!
+    var cryptoMock: KeyManagementServiceMock!
+    
+    override func setUp() {
+        relayMock = MockedWCRelay()
+        storageMock = SessionSequenceStorageMock()
+        cryptoMock = KeyManagementServiceMock()
+        sut = NonControllerSessionStateMachine(relay: relayMock, kms: cryptoMock, sequencesStore: storageMock, logger: ConsoleLoggerMock())
+    }
+    
+    override func tearDown() {
+        relayMock = nil
+        storageMock = nil
+        cryptoMock = nil
+        sut = nil
+    }
+    
+    // MARK: - Update Methods
+    
+    func testUpdateMethodsPeerSuccess() {
+        var didCallbackUpgrade = false
+        let session = SessionSequence.stub(isSelfController: false)
+        storageMock.setSequence(session)
+        sut.onMethodsUpdate = { topic, _ in
+            didCallbackUpgrade = true
+            XCTAssertEqual(topic, session.topic)
+        }
+        relayMock.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateMethods(topic: session.topic))
+        XCTAssertTrue(didCallbackUpgrade)
+        XCTAssertTrue(relayMock.didRespondSuccess)
+    }
+    
+    func testUpdateMethodsPeerErrorInvalidPermissions() {
+        let invalidMethods: Set<String> = [""]
+        let session = SessionSequence.stub(isSelfController: false)
+        storageMock.setSequence(session)
+        relayMock.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateMethods(topic: session.topic, methods: invalidMethods))
+        XCTAssertEqual(relayMock.lastErrorCode, 1004)
+    }
+
+    func testUpdateMethodPeerErrorSessionNotFound() {
+        relayMock.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateMethods(topic: ""))
+        XCTAssertFalse(relayMock.didRespondSuccess)
+        XCTAssertEqual(relayMock.lastErrorCode, 1301)
+    }
+
+    func testUpdateMethodPeerErrorUnauthorized() {
+        let session = SessionSequence.stub(isSelfController: true) // Peer is not a controller
+        storageMock.setSequence(session)
+        relayMock.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateMethods(topic: session.topic))
+        XCTAssertFalse(relayMock.didRespondSuccess)
+        XCTAssertEqual(relayMock.lastErrorCode, 3004)
+    }
+}

--- a/Tests/WalletConnectTests/PairingEngineTests.swift
+++ b/Tests/WalletConnectTests/PairingEngineTests.swift
@@ -217,11 +217,7 @@ final class PairingEngineTests: XCTestCase {
         XCTAssert(cryptoMock.hasSymmetricKey(for: pairing.topic), "Proposer must not delete symmetric key if pairing is active.")
         XCTAssertFalse(cryptoMock.hasPrivateKey(for: proposal.proposer.publicKey), "Proposer must remove private key for rejected session")
     }
-    
-    func testExtendPairingExpiryOnProposeResponse() {
-        
-    }
-    
+
     func testPairingExpiration() {
         let uri = engine.create()!
         let pairing = storageMock.getSequence(forTopic: uri.topic)!

--- a/Tests/WalletConnectTests/PairingSequenceTests.swift
+++ b/Tests/WalletConnectTests/PairingSequenceTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import WalletConnect
+
+final class PairingSequenceTests: XCTestCase {
+    
+    var referenceDate: Date!
+    
+    override func setUp() {
+        referenceDate = Date()
+        func getDate() -> Date { return referenceDate }
+        PairingSequence.dateInitializer = getDate
+    }
+    
+    override func tearDown() {
+        PairingSequence.dateInitializer = Date.init
+    }
+    
+    func testAbsoluteValues() {
+        
+    }
+    
+    func testInitInactiveFromTopic() {
+        let pairing = PairingSequence.build("", selfMetadata: AppMetadata.stub())
+        let inactiveExpiry = referenceDate.advanced(by: TimeInterval(PairingSequence.timeToLiveInactive))
+        XCTAssertFalse(pairing.isActive)
+        XCTAssertEqual(pairing.expiryDate, inactiveExpiry)
+    }
+    
+    func testInitInactiveFromURI() {
+        
+    }
+}

--- a/Tests/WalletConnectTests/PairingSequenceTests.swift
+++ b/Tests/WalletConnectTests/PairingSequenceTests.swift
@@ -21,12 +21,15 @@ final class PairingSequenceTests: XCTestCase {
     
     func testInitInactiveFromTopic() {
         let pairing = PairingSequence.build("", selfMetadata: AppMetadata.stub())
-        let inactiveExpiry = referenceDate.advanced(by: TimeInterval(PairingSequence.timeToLiveInactive))
+        let inactiveExpiry = referenceDate.advanced(by: PairingSequence.timeToLiveInactive)
         XCTAssertFalse(pairing.isActive)
         XCTAssertEqual(pairing.expiryDate, inactiveExpiry)
     }
     
     func testInitInactiveFromURI() {
-        
+        let pairing = PairingSequence.createFromURI(WalletConnectURI.stub())
+        let inactiveExpiry = referenceDate.advanced(by: PairingSequence.timeToLiveInactive)
+        XCTAssertFalse(pairing.isActive)
+        XCTAssertEqual(pairing.expiryDate, inactiveExpiry)
     }
 }

--- a/Tests/WalletConnectTests/PairingSequenceTests.swift
+++ b/Tests/WalletConnectTests/PairingSequenceTests.swift
@@ -34,7 +34,7 @@ final class PairingSequenceTests: XCTestCase {
         XCTAssertEqual(pairing.expiryDate, inactiveExpiry)
     }
     
-    func testExtend() {
+    func testUpdateExpiry() {
         var pairing = PairingSequence(topic: "", selfMetadata: AppMetadata.stub())
         let activeExpiry = referenceDate.advanced(by: PairingSequence.timeToLiveActive)
         try? pairing.updateExpiry()

--- a/Tests/WalletConnectTests/PairingSequenceTests.swift
+++ b/Tests/WalletConnectTests/PairingSequenceTests.swift
@@ -40,4 +40,12 @@ final class PairingSequenceTests: XCTestCase {
         try? pairing.extend()
         XCTAssertEqual(pairing.expiryDate, activeExpiry)
     }
+    
+    func testActivate() {
+        var pairing = PairingSequence(topic: "", selfMetadata: AppMetadata.stub())
+        let activeExpiry = referenceDate.advanced(by: PairingSequence.timeToLiveActive)
+        pairing.activate()
+        XCTAssertTrue(pairing.isActive)
+        XCTAssertEqual(pairing.expiryDate, activeExpiry)
+    }
 }

--- a/Tests/WalletConnectTests/PairingSequenceTests.swift
+++ b/Tests/WalletConnectTests/PairingSequenceTests.swift
@@ -37,7 +37,7 @@ final class PairingSequenceTests: XCTestCase {
     func testExtend() {
         var pairing = PairingSequence(topic: "", selfMetadata: AppMetadata.stub())
         let activeExpiry = referenceDate.advanced(by: PairingSequence.timeToLiveActive)
-        try? pairing.extend()
+        try? pairing.updateExpiry()
         XCTAssertEqual(pairing.expiryDate, activeExpiry)
     }
     

--- a/Tests/WalletConnectTests/PairingSequenceTests.swift
+++ b/Tests/WalletConnectTests/PairingSequenceTests.swift
@@ -33,4 +33,11 @@ final class PairingSequenceTests: XCTestCase {
         XCTAssertFalse(pairing.isActive)
         XCTAssertEqual(pairing.expiryDate, inactiveExpiry)
     }
+    
+    func testExtend() {
+        var pairing = PairingSequence(topic: "", selfMetadata: AppMetadata.stub())
+        let activeExpiry = referenceDate.advanced(by: PairingSequence.timeToLiveActive)
+        try? pairing.extend()
+        XCTAssertEqual(pairing.expiryDate, activeExpiry)
+    }
 }

--- a/Tests/WalletConnectTests/PairingSequenceTests.swift
+++ b/Tests/WalletConnectTests/PairingSequenceTests.swift
@@ -16,18 +16,19 @@ final class PairingSequenceTests: XCTestCase {
     }
     
     func testAbsoluteValues() {
-        
+        XCTAssertEqual(PairingSequence.timeToLiveInactive, 5 * .minute, "Inactive time-to-live is 5 minutes.")
+        XCTAssertEqual(PairingSequence.timeToLiveActive, 30 * .day, "Active time-to-live is 30 days.")
     }
     
     func testInitInactiveFromTopic() {
-        let pairing = PairingSequence.build("", selfMetadata: AppMetadata.stub())
+        let pairing = PairingSequence(topic: "", selfMetadata: AppMetadata.stub())
         let inactiveExpiry = referenceDate.advanced(by: PairingSequence.timeToLiveInactive)
         XCTAssertFalse(pairing.isActive)
         XCTAssertEqual(pairing.expiryDate, inactiveExpiry)
     }
     
     func testInitInactiveFromURI() {
-        let pairing = PairingSequence.createFromURI(WalletConnectURI.stub())
+        let pairing = PairingSequence(uri: WalletConnectURI.stub())
         let inactiveExpiry = referenceDate.advanced(by: PairingSequence.timeToLiveInactive)
         XCTAssertFalse(pairing.isActive)
         XCTAssertEqual(pairing.expiryDate, inactiveExpiry)

--- a/Tests/WalletConnectTests/Stub/Stubs.swift
+++ b/Tests/WalletConnectTests/Stub/Stubs.swift
@@ -45,14 +45,19 @@ extension AgreementPeer {
 }
 
 extension WCRequestSubscriptionPayload {
-    static func stubUpdate(topic: String, accounts: Set<String> = ["std:0:0"]) -> WCRequestSubscriptionPayload {
+    static func stubUpdateAccounts(topic: String, accounts: Set<String> = ["std:0:0"]) -> WCRequestSubscriptionPayload {
         let updateMethod = WCMethod.wcSessionUpdateAccounts(SessionType.UpdateAccountsParams(accounts: accounts)).asRequest()
         return WCRequestSubscriptionPayload(topic: topic, wcRequest: updateMethod)
     }
     
-    static func stubExtend(topic: String, expiry: Int64) -> WCRequestSubscriptionPayload {
-        let extendMethod = WCMethod.wcSessionUpdateExpiry(SessionType.UpdateExpiryParams(expiry: expiry)).asRequest()
-        return WCRequestSubscriptionPayload(topic: topic, wcRequest: extendMethod)
+    static func stubUpdateMethods(topic: String, methods: Set<String> = ["std:0:0"]) -> WCRequestSubscriptionPayload {
+        let updateMethod = WCMethod.wcSessionUpdateMethods(SessionType.UpdateMethodsParams(methods: methods)).asRequest()
+        return WCRequestSubscriptionPayload(topic: topic, wcRequest: updateMethod)
+    }
+    
+    static func stubUpdateExpiry(topic: String, expiry: Int64) -> WCRequestSubscriptionPayload {
+        let updateExpiryMethod = WCMethod.wcSessionUpdateExpiry(SessionType.UpdateExpiryParams(expiry: expiry)).asRequest()
+        return WCRequestSubscriptionPayload(topic: topic, wcRequest: updateExpiryMethod)
     }
     
     static func stubSettle(topic: String) -> WCRequestSubscriptionPayload {


### PR DESCRIPTION
- Add tests for pairing expiry dates and updates.
- Replaces legacy factory method from when a pairing had multiple sub-states.
- Binds extended expiry with activation.