### PR TITLE
[TV] tvOS Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
     name: "WalletConnect",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_15)
+        .macOS(.v10_15),
+        .tvOS(.v13),
     ],
     products: [
         .library(


### PR DESCRIPTION
One line change and works like a charm

- Package.swift updated with `.tvOS(.v13)`

It could be useful for some projects. 
I'm not sure what we need to build tvOS on CI, cause this is not main use case. Otherwise we could remove if any problems occurs.