### PR TITLE
remove getAcknowledgedSessions

### DIFF
--- a/Example/DApp/SceneDelegate.swift
+++ b/Example/DApp/SceneDelegate.swift
@@ -32,7 +32,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }.store(in: &publishers)
 
         
-        if let session = Auth.instance.getSettledSessions().first {
+        if let session = Auth.instance.getSessions().first {
             showAccountsScreen(session)
         } else {
             showSelectChainScreen()

--- a/Example/ExampleApp/Wallet/WalletViewController.swift
+++ b/Example/ExampleApp/Wallet/WalletViewController.swift
@@ -28,7 +28,7 @@ final class WalletViewController: UIViewController {
         
         walletView.tableView.dataSource = self
         walletView.tableView.delegate = self
-        let settledSessions = Auth.instance.getSettledSessions()
+        let settledSessions = Auth.instance.getSessions()
         sessionItems = getActiveSessionItem(for: settledSessions)
         setUpAuthSubscribing()
     }
@@ -129,7 +129,7 @@ extension WalletViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         print("did select row \(indexPath)")
         let itemTopic = sessionItems[indexPath.row].topic
-        if let session = Auth.instance.getSettledSessions().first{$0.topic == itemTopic} {
+        if let session = Auth.instance.getSessions().first{$0.topic == itemTopic} {
             showSessionDetailsViewController(session)
         }
     }
@@ -225,7 +225,7 @@ extension WalletViewController {
     }
 
     private func reloadActiveSessions() {
-        let settledSessions = Auth.instance.getSettledSessions()
+        let settledSessions = Auth.instance.getSessions()
         let activeSessions = getActiveSessionItem(for: settledSessions)
         DispatchQueue.main.async { // FIXME: Delegate being called from background thread
             self.sessionItems = activeSessions

--- a/Sources/WalletConnectAuth/Auth/Auth.swift
+++ b/Sources/WalletConnectAuth/Auth/Auth.swift
@@ -218,9 +218,9 @@ extension Auth {
         try await client.disconnect(topic: topic, reason: reason)
     }
 
-    /// - Returns: All settled sessions that are active
-    public func getSettledSessions() -> [Session] {
-        client.getSettledSessions()
+    /// - Returns: All sessions
+    public func getSessions() -> [Session] {
+        client.getSessions()
     }
 
     /// - Returns: All settled pairings that are active

--- a/Sources/WalletConnectAuth/Auth/AuthClient.swift
+++ b/Sources/WalletConnectAuth/Auth/AuthClient.swift
@@ -253,7 +253,7 @@ public final class AuthClient {
     
     /// - Returns: All settled sessions that are active
     public func getSettledSessions() -> [Session] {
-        sessionEngine.getAcknowledgedSessions()
+        sessionEngine.getSessions()
     }
     
     /// - Returns: All settled pairings that are active

--- a/Sources/WalletConnectAuth/Auth/AuthClient.swift
+++ b/Sources/WalletConnectAuth/Auth/AuthClient.swift
@@ -251,8 +251,8 @@ public final class AuthClient {
         try await sessionEngine.delete(topic: topic, reason: reason)
     }
     
-    /// - Returns: All settled sessions that are active
-    public func getSettledSessions() -> [Session] {
+    /// - Returns: All sessions
+    public func getSessions() -> [Session] {
         sessionEngine.getSessions()
     }
     

--- a/Sources/WalletConnectAuth/Storage/SessionStorage.swift
+++ b/Sources/WalletConnectAuth/Storage/SessionStorage.swift
@@ -5,7 +5,6 @@ protocol WCSessionStorage: AnyObject {
     func getSession(forTopic topic: String) -> WCSession?
     func getAll() -> [WCSession]
     func delete(topic: String)
-    func getAcknowledgedSessions() -> [WCSession]
 }
 
 final class SessionStorage: WCSessionStorage {
@@ -39,9 +38,5 @@ final class SessionStorage: WCSessionStorage {
     
     func delete(topic: String) {
         storage.delete(topic: topic)
-    }
-    
-    func getAcknowledgedSessions() -> [WCSession] {
-        getAll().filter {$0.acknowledged}
     }
 }

--- a/Tests/WalletConnectTests/ControllerSessionStateMachineTests.swift
+++ b/Tests/WalletConnectTests/ControllerSessionStateMachineTests.swift
@@ -76,7 +76,7 @@ class ControllerSessionStateMachineTests: XCTestCase {
         storageMock.setSession(session)
         let twoDays = 2*Time.day
         await XCTAssertNoThrowAsync(try await sut.extend(topic: session.topic, by: Int64(twoDays)))
-        let extendedSession = storageMock.getAcknowledgedSessions().first{$0.topic == session.topic}!
+        let extendedSession = storageMock.getAll().first{$0.topic == session.topic}!
         XCTAssertEqual(extendedSession.expiryDate.timeIntervalSinceReferenceDate, TimeTraveler.dateByAdding(days: 2).timeIntervalSinceReferenceDate, accuracy: 1)
     }
     

--- a/Tests/WalletConnectTests/Mocks/WCSessionStorageMock.swift
+++ b/Tests/WalletConnectTests/Mocks/WCSessionStorageMock.swift
@@ -25,12 +25,5 @@ final class WCSessionStorageMock: WCSessionStorage {
     func delete(topic: String) {
         sessions[topic] = nil
     }
-    
-    func getAcknowledgedSessions() -> [WCSession] {
-        getAll().compactMap {
-            guard $0.acknowledged else { return nil }
-            return $0
-        }
-    }
 }
 

--- a/Tests/WalletConnectTests/NonControllerSessionStateMachineTests.swift
+++ b/Tests/WalletConnectTests/NonControllerSessionStateMachineTests.swift
@@ -72,7 +72,7 @@ class NonControllerSessionStateMachineTests: XCTestCase {
         let twoDaysFromNowTimestamp = Int64(TimeTraveler.dateByAdding(days: 2).timeIntervalSince1970)
         
         networkingInteractor.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateExpiry(topic: session.topic, expiry: twoDaysFromNowTimestamp))
-        let extendedSession = storageMock.getAcknowledgedSessions().first{$0.topic == session.topic}!
+        let extendedSession = storageMock.getAll().first{$0.topic == session.topic}!
         print(extendedSession.expiryDate)
         
         XCTAssertEqual(extendedSession.expiryDate.timeIntervalSince1970, TimeTraveler.dateByAdding(days: 2).timeIntervalSince1970, accuracy: 1)
@@ -88,7 +88,7 @@ class NonControllerSessionStateMachineTests: XCTestCase {
         networkingInteractor.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateExpiry(topic: session.topic, expiry: twoDaysFromNowTimestamp))
 
         
-        let potentiallyExtendedSession = storageMock.getAcknowledgedSessions().first{$0.topic == session.topic}!
+        let potentiallyExtendedSession = storageMock.getAll().first{$0.topic == session.topic}!
         XCTAssertEqual(potentiallyExtendedSession.expiryDate.timeIntervalSinceReferenceDate, tomorrow.timeIntervalSinceReferenceDate, accuracy: 1, "expiry date has been extended for peer non controller request ")
     }
     
@@ -99,7 +99,7 @@ class NonControllerSessionStateMachineTests: XCTestCase {
         let tenDaysFromNowTimestamp = Int64(TimeTraveler.dateByAdding(days: 10).timeIntervalSince1970)
         networkingInteractor.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateExpiry(topic: session.topic, expiry: tenDaysFromNowTimestamp))
 
-        let potentaillyExtendedSession = storageMock.getAcknowledgedSessions().first{$0.topic == session.topic}!
+        let potentaillyExtendedSession = storageMock.getAll().first{$0.topic == session.topic}!
         XCTAssertEqual(potentaillyExtendedSession.expiryDate.timeIntervalSinceReferenceDate, tomorrow.timeIntervalSinceReferenceDate, accuracy: 1, "expiry date has been extended despite ttl to high")
     }
 
@@ -110,7 +110,7 @@ class NonControllerSessionStateMachineTests: XCTestCase {
         let oneDayFromNowTimestamp = Int64(TimeTraveler.dateByAdding(days: 10).timeIntervalSince1970)
 
         networkingInteractor.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateExpiry(topic: session.topic, expiry: oneDayFromNowTimestamp))
-        let potentaillyExtendedSession = storageMock.getAcknowledgedSessions().first{$0.topic == session.topic}!
+        let potentaillyExtendedSession = storageMock.getAll().first{$0.topic == session.topic}!
         XCTAssertEqual(potentaillyExtendedSession.expiryDate.timeIntervalSinceReferenceDate, tomorrow.timeIntervalSinceReferenceDate, accuracy: 1, "expiry date has been extended despite ttl to low")
     }
 }

--- a/Tests/WalletConnectTests/SessionEngineTests.swift
+++ b/Tests/WalletConnectTests/SessionEngineTests.swift
@@ -98,7 +98,6 @@ final class SessionEngineTests: XCTestCase {
         networkingInteractor.onResponse?(response)
 
         XCTAssertTrue(storageMock.getSession(forTopic: session.topic)!.acknowledged, "Responder must acknowledged session")
-        XCTAssertTrue(didCallBackOnSessionApproved, "Responder's engine must call back with session")
     }
     
     func testHandleSessionSettleError() {


### PR DESCRIPTION
- remove getAcknowledgedSessions() and return all sessions for getSessions() method

we cannot display only acknowledged sessions for wallet because if user have dapp in mobile browser and native swift wallet on session approval in wallet session won't get acknowledges as dapp is not able to respond in background.