### PR TITLE
#250 Integration Tests: Re-enable session propose-approve test case

### DIFF
--- a/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
@@ -180,7 +180,9 @@ private extension ApproveEngine {
             )
             settlingProposal = proposal
 
-            Task { try? await networkingInteractor.subscribe(topic: sessionTopic) }
+            Task(priority: .background) {
+                try? await networkingInteractor.subscribe(topic: sessionTopic)
+            }
         }
         catch {
             guard let error = error as? JSONRPCErrorResponse else {

--- a/Sources/WalletConnectSign/Namespace.swift
+++ b/Sources/WalletConnectSign/Namespace.swift
@@ -19,7 +19,7 @@ public struct ProposalNamespace: Equatable, Codable {
         }
     }
     
-    public init(chains: Set<Blockchain>, methods: Set<String>, events: Set<String>, extensions: [ProposalNamespace.Extension]?) {
+    public init(chains: Set<Blockchain>, methods: Set<String>, events: Set<String>, extensions: [ProposalNamespace.Extension]? = nil) {
         self.chains = chains
         self.methods = methods
         self.events = events
@@ -46,7 +46,7 @@ public struct SessionNamespace: Equatable, Codable {
         }
     }
     
-    public init(accounts: Set<Account>, methods: Set<String>, events: Set<String>, extensions: [SessionNamespace.Extension]?) {
+    public init(accounts: Set<Account>, methods: Set<String>, events: Set<String>, extensions: [SessionNamespace.Extension]? = nil) {
         self.accounts = accounts
         self.methods = methods
         self.events = events

--- a/Sources/WalletConnectSign/Sign/SignClient.swift
+++ b/Sources/WalletConnectSign/Sign/SignClient.swift
@@ -21,9 +21,10 @@ import UIKit
 ///     - delegate: The object that acts as the delegate of WalletConnect Client
 ///     - logger: An object for logging messages
 public final class SignClient {
+    
     public weak var delegate: SignClientDelegate?
+    
     public let logger: ConsoleLogging
-    private var publishers = [AnyCancellable]()
     private let metadata: AppMetadata
     private let pairingEngine: PairingEngine
     private let pairEngine: PairEngine
@@ -35,6 +36,7 @@ public final class SignClient {
     private let kms: KeyManagementService
     private let history: JsonRpcHistory
     private let cleanupService: CleanupService
+    private var publishers = [AnyCancellable]()
 
     // MARK: - Initializers
 

--- a/Sources/WalletConnectUtils/KeyValueStorage.swift
+++ b/Sources/WalletConnectUtils/KeyValueStorage.swift
@@ -16,7 +16,6 @@ public protocol KeyValueStorage {
 
 extension UserDefaults: KeyValueStorage {}
 
-// TODO: Move to test target
 public final class RuntimeKeyValueStorage: KeyValueStorage {
     private var storage: [String : Any] = [:]
     private let queue = DispatchQueue(label: "com.walletconnect.sdk.runtimestorage")

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -91,7 +91,7 @@ final class ClientTests: XCTestCase {
             group.leave()
         }
         group.wait()
-        //
+        // -----------
         
         let dappSettlementExpectation = expectation(description: "Dapp expects to settle a session")
         let walletSettlementExpectation = expectation(description: "Wallet expects to settle a session")
@@ -100,10 +100,11 @@ final class ClientTests: XCTestCase {
         let sessionNamespaces = SessionNamespace.make(toRespond: requiredNamespaces)
         
         wallet.onSessionProposal = { proposal in
-            print("RECEIVED PROPOSAL ===========================")
             do {
-                try dapp.client.approve(proposalId: proposal.id, namespaces: sessionNamespaces)
-            } catch { XCTFail() }
+                try wallet.client.approve(proposalId: proposal.id, namespaces: sessionNamespaces)
+            } catch {
+                XCTFail("\(error)")
+            }
         }
         dapp.onSessionSettled = { _ in
             dappSettlementExpectation.fulfill()

--- a/Tests/IntegrationTests/Helpers/Stubs.swift
+++ b/Tests/IntegrationTests/Helpers/Stubs.swift
@@ -1,0 +1,24 @@
+import WalletConnectSign
+
+extension ProposalNamespace {
+    static func stubRequired() -> [String: ProposalNamespace] {
+        return [
+            "eip155": ProposalNamespace(
+                chains: [Blockchain("eip155:1")!],
+                methods: ["personal_sign"],
+                events: [])
+        ]
+    }
+}
+
+extension SessionNamespace {
+    static func make(toRespond namespaces: [String: ProposalNamespace]) -> [String: SessionNamespace] {
+        return namespaces.mapValues { proposalNamespace in
+            SessionNamespace(
+                accounts: Set(proposalNamespace.chains.map { Account(blockchain: $0, address: "0x00")! }),
+                methods: proposalNamespace.methods,
+                events: proposalNamespace.events
+            )
+        }
+    }
+}

--- a/Tests/IntegrationTests/SignClientTests.swift
+++ b/Tests/IntegrationTests/SignClientTests.swift
@@ -4,7 +4,7 @@ import TestingUtils
 @testable import WalletConnectKMS
 @testable import WalletConnectSign
 
-final class ClientTests: XCTestCase {
+final class SignClientTests: XCTestCase {
 
     let defaultTimeout: TimeInterval = 5.0
 

--- a/Tests/IntegrationTests/SignClientTests.swift
+++ b/Tests/IntegrationTests/SignClientTests.swift
@@ -13,7 +13,6 @@ final class SignClientTests: XCTestCase {
 
     static private func makeClientDelegate(
         name: String,
-        isController: Bool,
         relayHost: String = "relay.walletconnect.com",
         projectId: String = "8ba9ee138960775e5231b70cc5ef1c3a"
     ) -> ClientDelegate {
@@ -44,8 +43,8 @@ final class SignClientTests: XCTestCase {
     }
     
     override func setUp() async throws {
-        proposer = Self.makeClientDelegate(name: "🍏P", isController: false)
-        responder = Self.makeClientDelegate(name: "🍎R", isController: true)
+        proposer = Self.makeClientDelegate(name: "🍏P")
+        responder = Self.makeClientDelegate(name: "🍎R")
         await listenForConnection()
     }
     

--- a/Tests/TestingUtils/Mocks/KeychainServiceFake.swift
+++ b/Tests/TestingUtils/Mocks/KeychainServiceFake.swift
@@ -1,12 +1,15 @@
 import Foundation
 @testable import WalletConnectKMS
 
-// This file is a copy from the one in unit tests target, would be nice to figure out a way to share it between targets.
 final public class KeychainServiceFake: KeychainServiceProtocol {
     
     var errorStatus: OSStatus?
     
-    private var storage: [String: Data] = [:]
+    private var storage: [String: Data]
+    
+    public init() {
+        self.storage = [:]
+    }
     
     public func add(_ attributes: CFDictionary, _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
         if let forceError = errorStatus {


### PR DESCRIPTION
### Overview
Re-enable the first test case of the integration tests target.

### Changes
- Uncommented and cleaned proposal+approval integration test case.
- Change the priority of the `Task` in approval engine's `handleSessionProposeResponse` to `.background` to avoid deadlocking during the async test.

### Next steps:
- Re-enable next test cases.