### PR TITLE
ApproveEngine async calls

### DIFF
--- a/Example/ExampleApp/SessionDetails/SessionDetailViewController.swift
+++ b/Example/ExampleApp/SessionDetails/SessionDetailViewController.swift
@@ -36,18 +36,18 @@ final class SessionDetailViewController: UIHostingController<SessionDetailView> 
     }
     
     private func respondOnSign(request: Request, response: JSONRPCResponse<AnyCodable>) {
-        print("[CONTROLLER] Respond on Sign")
+        print("[WALLET] Respond on Sign")
         Task {
             do {
                 try await Sign.instance.respond(topic: request.topic, response: .response(response))
             } catch {
-                print("[NON-CONTROLLER] Respond Error: \(error.localizedDescription)")
+                print("[DAPP] Respond Error: \(error.localizedDescription)")
             }
         }
     }
     
     private func respondOnReject(request: Request) {
-        print("[CONTROLLER] Respond on Reject")
+        print("[WALLET] Respond on Reject")
         Task {
             do {
                 try await Sign.instance.respond(
@@ -58,7 +58,7 @@ final class SessionDetailViewController: UIHostingController<SessionDetailView> 
                     )
                 )
             } catch {
-                print("[NON-CONTROLLER] Respond Error: \(error.localizedDescription)")
+                print("[DAPP] Respond Error: \(error.localizedDescription)")
             }
         }
     }

--- a/Example/ExampleApp/SessionDetails/SessionDetailViewController.swift
+++ b/Example/ExampleApp/SessionDetails/SessionDetailViewController.swift
@@ -25,20 +25,42 @@ final class SessionDetailViewController: UIHostingController<SessionDetailView> 
         viewController.onSign = { [unowned self] in
             let result = Signer.signEth(request: request)
             let response = JSONRPCResponse<AnyCodable>(id: request.id, result: result)
-            Sign.instance.respond(topic: request.topic, response: .response(response))
+            respondOnSign(request: request, response: response)
             reload()
         }
         viewController.onReject = { [unowned self] in
-            Sign.instance.respond(
-                topic: request.topic,
-                response: .error(JSONRPCErrorResponse(
-                    id: request.id,
-                    error: JSONRPCErrorResponse.Error(code: 0, message: ""))
-                )
-            )
+            respondOnReject(request: request)
             reload()
         }
         present(viewController, animated: true)
+    }
+    
+    private func respondOnSign(request: Request, response: JSONRPCResponse<AnyCodable>) {
+        print("[CONTROLLER] Respond on Sign")
+        Task {
+            do {
+                try await Sign.instance.respond(topic: request.topic, response: .response(response))
+            } catch {
+                print("[NON-CONTROLLER] Respond Error: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    private func respondOnReject(request: Request) {
+        print("[CONTROLLER] Respond on Reject")
+        Task {
+            do {
+                try await Sign.instance.respond(
+                    topic: request.topic,
+                    response: .error(JSONRPCErrorResponse(
+                        id: request.id,
+                        error: JSONRPCErrorResponse.Error(code: 0, message: ""))
+                    )
+                )
+            } catch {
+                print("[NON-CONTROLLER] Respond Error: \(error.localizedDescription)")
+            }
+        }
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {

--- a/Example/ExampleApp/Wallet/WalletViewController.swift
+++ b/Example/ExampleApp/Wallet/WalletViewController.swift
@@ -80,7 +80,8 @@ final class WalletViewController: UIViewController {
             viewController.reload()
         }
     }
-    
+
+    @MainActor
     private func respondOnSign(request: Request, response: JSONRPCResponse<AnyCodable>) {
         print("[WALLET] Respond on Sign")
         Task {
@@ -91,7 +92,8 @@ final class WalletViewController: UIViewController {
             }
         }
     }
-    
+
+    @MainActor
     private func respondOnReject(request: Request) {
         print("[WALLET] Respond on Reject")
         Task {
@@ -108,7 +110,8 @@ final class WalletViewController: UIViewController {
             }
         }
     }
-    
+
+    @MainActor
     private func pairClient(uri: String) {
         print("[WALLET] Pairing to: \(uri)")
         Task {
@@ -119,7 +122,8 @@ final class WalletViewController: UIViewController {
             }
         }
     }
-    
+
+    @MainActor
     private func approve(proposalId: String, namespaces: [String : SessionNamespace]) {
         print("[WALLET] Approve Session: \(proposalId)")
         Task {
@@ -130,7 +134,8 @@ final class WalletViewController: UIViewController {
             }
         }
     }
-    
+
+    @MainActor
     private func reject(proposalId: String, reason: RejectionReason) {
         print("[WALLET] Reject Session: \(proposalId)")
         Task {
@@ -154,7 +159,8 @@ extension WalletViewController: UITableViewDataSource, UITableViewDelegate {
         cell.item = sessionItems[indexPath.row]
         return cell
     }
-    
+
+    @MainActor
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
             let item = sessionItems[indexPath.row]

--- a/Example/ExampleApp/Wallet/WalletViewController.swift
+++ b/Example/ExampleApp/Wallet/WalletViewController.swift
@@ -82,18 +82,18 @@ final class WalletViewController: UIViewController {
     }
     
     private func respondOnSign(request: Request, response: JSONRPCResponse<AnyCodable>) {
-        print("[CONTROLLER] Respond on Sign")
+        print("[WALLET] Respond on Sign")
         Task {
             do {
                 try await Sign.instance.respond(topic: request.topic, response: .response(response))
             } catch {
-                print("[NON-CONTROLLER] Respond Error: \(error.localizedDescription)")
+                print("[DAPP] Respond Error: \(error.localizedDescription)")
             }
         }
     }
     
     private func respondOnReject(request: Request) {
-        print("[CONTROLLER] Respond on Reject")
+        print("[WALLET] Respond on Reject")
         Task {
             do {
                 try await Sign.instance.respond(
@@ -104,40 +104,40 @@ final class WalletViewController: UIViewController {
                     )
                 )
             } catch {
-                print("[NON-CONTROLLER] Respond Error: \(error.localizedDescription)")
+                print("[DAPP] Respond Error: \(error.localizedDescription)")
             }
         }
     }
     
     private func pairClient(uri: String) {
-        print("[CONTROLLER] Pairing to: \(uri)")
+        print("[WALLET] Pairing to: \(uri)")
         Task {
             do {
                 try await Sign.instance.pair(uri: uri)
             } catch {
-                print("[NON-CONTROLLER] Pairing connect error: \(error)")
+                print("[DAPP] Pairing connect error: \(error)")
             }
         }
     }
     
     private func approve(proposalId: String, namespaces: [String : SessionNamespace]) {
-        print("[CONTROLLER] Approve Session: \(proposalId)")
+        print("[WALLET] Approve Session: \(proposalId)")
         Task {
             do {
                 try await Sign.instance.approve(proposalId: proposalId, namespaces: namespaces)
             } catch {
-                print("[NON-CONTROLLER] Approve Session error: \(error)")
+                print("[DAPP] Approve Session error: \(error)")
             }
         }
     }
     
     private func reject(proposalId: String, reason: RejectionReason) {
-        print("[CONTROLLER] Reject Session: \(proposalId)")
+        print("[WALLET] Reject Session: \(proposalId)")
         Task {
             do {
                 try await Sign.instance.reject(proposalId: proposalId, reason: reason)
             } catch {
-                print("[NON-CONTROLLER] Reject Session error: \(error)")
+                print("[DAPP] Reject Session error: \(error)")
             }
         }
     }

--- a/Example/UITests/Engine/RoutingEngine.swift
+++ b/Example/UITests/Engine/RoutingEngine.swift
@@ -21,8 +21,9 @@ struct RoutingEngine {
     }
     
     func activate(app: App) {
-        app.instance.activate()
-        app.instance.waitForAppearence()
+        let app = app.instance
+        app.activate()
+        app.waitForAppearence()
     }
     
     func home() {

--- a/Example/UITests/Regression/RegressionTests.swift
+++ b/Example/UITests/Regression/RegressionTests.swift
@@ -19,7 +19,7 @@ class PairingTests: XCTestCase {
         engine.routing.activate(app: .dapp)
 
         // TODO: Figure out why you need to wait here
-        engine.routing.wait(for: 2)
+        engine.routing.wait(for: 3)
 
         engine.dapp.connectButton.waitTap()
 

--- a/Sources/WalletConnectKMS/Serialiser/Serializer.swift
+++ b/Sources/WalletConnectKMS/Serialiser/Serializer.swift
@@ -40,7 +40,6 @@ public class Serializer {
     /// - Returns: Deserialized object
     public func tryDeserialize<T: Codable>(topic: String, message: String) -> T? {
         do {
-            let deserializedCodable: T
             if let symmetricKey = kms.getSymmetricKeyRepresentable(for: topic) {
                 return try deserialize(message: message, symmetricKey: symmetricKey)
             } else {

--- a/Sources/WalletConnectRelay/RelayClient.swift
+++ b/Sources/WalletConnectRelay/RelayClient.swift
@@ -86,24 +86,13 @@ public final class RelayClient {
     }
     
     /// Completes when networking client sends a request, error if it fails on client side
-    public func publish(
-        topic: String,
-        payload: String,
-        prompt: Bool = false) async throws {
-            let params = RelayJSONRPC.PublishParams(topic: topic, message: payload, ttl: defaultTtl, prompt: prompt)
-            let request = JSONRPCRequest<RelayJSONRPC.PublishParams>(method: RelayJSONRPC.Method.publish.rawValue, params: params)
-            let requestJson = try! request.json()
-            logger.debug("Publishing Payload on Topic: \(topic)")
-            return try await withCheckedThrowingContinuation { continuation in
-                dispatcher.send(requestJson) { error in
-                    if let error = error {
-                        continuation.resume(throwing: error)
-                        return
-                    }
-                    continuation.resume(returning: ())
-                }
-            }
-        }
+    public func publish(topic: String, payload: String, prompt: Bool = false) async throws {
+        let params = RelayJSONRPC.PublishParams(topic: topic, message: payload, ttl: defaultTtl, prompt: prompt)
+        let request = JSONRPCRequest<RelayJSONRPC.PublishParams>(method: RelayJSONRPC.Method.publish.rawValue, params: params)
+        logger.debug("Publishing Payload on Topic: \(topic)")
+        let requestJson = try request.json()
+        try await dispatcher.send(requestJson)
+    }
     
     /// Completes with an acknowledgement from the relay network.
     @discardableResult public func publish(

--- a/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
@@ -175,7 +175,7 @@ private extension ApproveEngine {
             do {
                 try await networkingInteractor.respondError(payload: payload, reason: reason)
             } catch {
-                logger.error("Respond Error: \(error.localizedDescription)")
+                logger.error("Respond Error failed with: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
@@ -52,7 +52,7 @@ final class ApproveEngine {
         setupNetworkingSubscriptions()
     }
     
-    func approveProposal(proposerPubKey: String, validating sessionNamespaces: [String: SessionNamespace]) throws {
+    func approveProposal(proposerPubKey: String, validating sessionNamespaces: [String: SessionNamespace]) async throws {
         let payload = try proposalPayloadsStore.get(key: proposerPubKey)
 
         guard let payload = payload, case .sessionPropose(let proposal) = payload.wcRequest.params else {
@@ -81,21 +81,21 @@ final class ApproveEngine {
 
         let proposeResponse = SessionType.ProposeResponse(relay: relay, responderPublicKey: selfPublicKey.hexRepresentation)
         let response = JSONRPCResponse<AnyCodable>(id: payload.wcRequest.id, result: AnyCodable(proposeResponse))
-        networkingInteractor.respond(topic: payload.topic, response: .response(response)) { _ in }
-
-        try settle(topic: sessionTopic, proposal: proposal, namespaces: sessionNamespaces)
+        
+        try await networkingInteractor.respond(topic: payload.topic, response: .response(response))
+        try await settle(topic: sessionTopic, proposal: proposal, namespaces: sessionNamespaces)
     }
     
-    func reject(proposerPubKey: String, reason: ReasonCode) throws {
+    func reject(proposerPubKey: String, reason: ReasonCode) async throws {
         guard let payload = try proposalPayloadsStore.get(key: proposerPubKey) else {
             throw Error.proposalPayloadsNotFound
         }
         proposalPayloadsStore.delete(forKey: proposerPubKey)
-        networkingInteractor.respondError(for: payload, reason: reason)
+        try await networkingInteractor.respondError(payload: payload, reason: reason)
         // TODO: Delete pairing if inactive
     }
     
-    func settle(topic: String, proposal: SessionProposal, namespaces: [String: SessionNamespace]) throws {
+    func settle(topic: String, proposal: SessionProposal, namespaces: [String: SessionNamespace]) async throws {
         guard let agreementKeys = try kms.getAgreementSecret(for: topic) else {
             throw Error.agreementMissingOrInvalid
         }
@@ -103,32 +103,34 @@ final class ApproveEngine {
             publicKey: agreementKeys.publicKey.hexRepresentation,
             metadata: metadata
         )
-        let expectedExpiryTimeStamp = Date().addingTimeInterval(TimeInterval(WCSession.defaultTimeToLive))
-        
         guard let relay = proposal.relays.first else {
             throw Error.relayNotFound
         }
 
         // TODO: Test expiration times
+        let expiry = Date()
+            .addingTimeInterval(TimeInterval(WCSession.defaultTimeToLive))
+            .timeIntervalSince1970
+    
         let settleParams = SessionType.SettleParams(
             relay: relay,
             controller: selfParticipant,
             namespaces: namespaces,
-            expiry: Int64(expectedExpiryTimeStamp.timeIntervalSince1970)
-        )
+            expiry: Int64(expiry))
+
         let session = WCSession(
             topic: topic,
             selfParticipant: selfParticipant,
             peerParticipant: proposal.proposer,
             settleParams: settleParams,
-            acknowledged: false
-        )
+            acknowledged: false)
 
         logger.debug("Sending session settle request")
 
-        Task { try? await networkingInteractor.subscribe(topic: topic) }
+        try await networkingInteractor.subscribe(topic: topic)
         sessionStore.setSession(session)
-        networkingInteractor.request(.wcSessionSettle(settleParams), onTopic: topic)
+
+        try await networkingInteractor.request(.wcSessionSettle(settleParams), onTopic: topic)
         onSessionSettle?(session.publicRepresentation())
     }
 }

--- a/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
@@ -143,7 +143,7 @@ private extension SessionEngine {
             do {
                 try await networkingInteractor.respondError(payload: payload, reason: reason)
             } catch {
-                logger.error("Respond Error: \(error.localizedDescription)")
+                logger.error("Respond Error failed with: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
@@ -4,8 +4,8 @@ import WalletConnectUtils
 import WalletConnectKMS
 
 final class SessionEngine {
-    
     enum Errors: Error {
+        case respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode)
         case sessionNotFound(topic: String)
     }
 
@@ -107,17 +107,22 @@ private extension SessionEngine {
     
     func setupNetworkingSubscriptions() {
         networkingInteractor.wcRequestPublisher.sink  { [unowned self] subscriptionPayload in
-            switch subscriptionPayload.wcRequest.params {
-            case .sessionDelete(let deleteParams):
-                onSessionDelete(subscriptionPayload, deleteParams: deleteParams)
-            case .sessionRequest(let sessionRequestParams):
-                onSessionRequest(subscriptionPayload, payloadParams: sessionRequestParams)
-            case .sessionPing(_):
-                onSessionPing(subscriptionPayload)
-            case .sessionEvent(let eventParams):
-                onSessionEvent(subscriptionPayload, eventParams: eventParams)
-            default:
-                return
+            do {
+                switch subscriptionPayload.wcRequest.params {
+                case .sessionDelete(let deleteParams):
+                    try onSessionDelete(subscriptionPayload, deleteParams: deleteParams)
+                case .sessionRequest(let sessionRequestParams):
+                    try onSessionRequest(subscriptionPayload, payloadParams: sessionRequestParams)
+                case .sessionPing(_):
+                    onSessionPing(subscriptionPayload)
+                case .sessionEvent(let eventParams):
+                    try onSessionEvent(subscriptionPayload, eventParams: eventParams)
+                default: return
+                }
+            } catch Errors.respondError(let payload, let reason) {
+                respondError(payload: payload, reason: reason)
+            } catch {
+                logger.error("Unexpected Error: \(error.localizedDescription)")
             }
         }.store(in: &publishers)
         
@@ -133,11 +138,20 @@ private extension SessionEngine {
             }.store(in: &publishers)
     }
     
-    func onSessionDelete(_ payload: WCRequestSubscriptionPayload, deleteParams: SessionType.DeleteParams) {
+    func respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode) {
+        Task {
+            do {
+                try await networkingInteractor.respondError(payload: payload, reason: reason)
+            } catch {
+                logger.error("Respond Error: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func onSessionDelete(_ payload: WCRequestSubscriptionPayload, deleteParams: SessionType.DeleteParams) throws {
         let topic = payload.topic
         guard sessionStore.hasSession(forTopic: topic) else {
-            networkingInteractor.respondError(for: payload, reason: .noContextWithTopic(context: .session, topic: topic))
-            return
+            throw Errors.respondError(payload: payload, reason: .noContextWithTopic(context: .session, topic: topic))
         }
         sessionStore.delete(topic: topic)
         networkingInteractor.unsubscribe(topic: topic)
@@ -145,7 +159,7 @@ private extension SessionEngine {
         onSessionDelete?(topic, deleteParams)
     }
     
-    func onSessionRequest(_ payload: WCRequestSubscriptionPayload, payloadParams: SessionType.RequestParams) {
+    func onSessionRequest(_ payload: WCRequestSubscriptionPayload, payloadParams: SessionType.RequestParams) throws {
         let topic = payload.topic
         let jsonRpcRequest = JSONRPCRequest<AnyCodable>(id: payload.wcRequest.id, method: payloadParams.request.method, params: payloadParams.request.params)
         let request = Request(
@@ -156,17 +170,14 @@ private extension SessionEngine {
             chainId: payloadParams.chainId)
         
         guard let session = sessionStore.getSession(forTopic: topic) else {
-            networkingInteractor.respondError(for: payload, reason: .noContextWithTopic(context: .session, topic: topic))
-            return
+            throw Errors.respondError(payload: payload, reason: .noContextWithTopic(context: .session, topic: topic))
         }
         let chain = request.chainId
         guard session.hasNamespace(for: chain) else {
-            networkingInteractor.respondError(for: payload, reason: .unauthorizedTargetChain(chain.absoluteString))
-            return
+            throw Errors.respondError(payload: payload, reason: .unauthorizedTargetChain(chain.absoluteString))
         }
         guard session.hasPermission(forMethod: request.method, onChain: chain) else {
-            networkingInteractor.respondError(for: payload, reason: .unauthorizedMethod(request.method))
-            return
+            throw Errors.respondError(payload: payload, reason: .unauthorizedMethod(request.method))
         }
         onSessionRequest?(request)
     }
@@ -175,19 +186,17 @@ private extension SessionEngine {
         networkingInteractor.respondSuccess(for: payload)
     }
     
-    func onSessionEvent(_ payload: WCRequestSubscriptionPayload, eventParams: SessionType.EventParams) {
+    func onSessionEvent(_ payload: WCRequestSubscriptionPayload, eventParams: SessionType.EventParams) throws {
         let event = eventParams.event
         let topic = payload.topic
         guard let session = sessionStore.getSession(forTopic: topic) else {
-            networkingInteractor.respondError(for: payload, reason: .noContextWithTopic(context: .session, topic: payload.topic))
-            return
+            throw Errors.respondError(payload: payload, reason: .noContextWithTopic(context: .session, topic: payload.topic))
         }
         guard
             session.peerIsController,
             session.hasPermission(forEvent: event.name, onChain: eventParams.chainId)
         else {
-            networkingInteractor.respondError(for: payload, reason: .unauthorizedEvent(event.name))
-            return
+            throw Errors.respondError(payload: payload, reason: .unauthorizedEvent(event.name))
         }
         networkingInteractor.respondSuccess(for: payload)
         onEventReceived?(topic, event.publicRepresentation(), eventParams.chainId)

--- a/Sources/WalletConnectSign/Engine/Controller/ControllerSessionStateMachine.swift
+++ b/Sources/WalletConnectSign/Engine/Controller/ControllerSessionStateMachine.swift
@@ -5,6 +5,7 @@ import WalletConnectKMS
 import Combine
 
 final class ControllerSessionStateMachine {
+
     var onNamespacesUpdate: ((String, [String: SessionNamespace])->())?
     var onExtend: ((String, Date)->())?
 
@@ -61,7 +62,7 @@ final class ControllerSessionStateMachine {
     
     // TODO: Re-enable callback
     private func handleUpdateResponse(topic: String, result: JsonRpcResult) {
-        guard let session = sessionStore.getSession(forTopic: topic) else {
+        guard let _ = sessionStore.getSession(forTopic: topic) else {
             return
         }
         switch result {

--- a/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
+++ b/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
@@ -51,9 +51,9 @@ final class NonControllerSessionStateMachine {
     private func respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode) {
         Task {
             do {
-                try await self.networkingInteractor.respondError(payload: payload, reason: reason)
+                try await networkingInteractor.respondError(payload: payload, reason: reason)
             } catch {
-                self.logger.error("Respond Error: \(error.localizedDescription)")
+                logger.error("Respond Error failed with: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
+++ b/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
@@ -5,7 +5,10 @@ import WalletConnectKMS
 import Combine
 
 final class NonControllerSessionStateMachine {
-    
+    enum Errors: Error {
+        case respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode)
+    }
+
     var onNamespacesUpdate: ((String, [String: SessionNamespace])->())?
     var onExtend: ((String, Date) -> ())?
     
@@ -27,33 +30,46 @@ final class NonControllerSessionStateMachine {
     }
     
     private func setUpWCRequestHandling() {
-        networkingInteractor.wcRequestPublisher.sink { [unowned self] subscriptionPayload in
-            switch subscriptionPayload.wcRequest.params {
-            case .sessionUpdate(let updateParams):
-                onSessionUpdateNamespacesRequest(payload: subscriptionPayload, updateParams: updateParams)
-            case .sessionExtend(let updateExpiryParams):
-                onSessionUpdateExpiry(subscriptionPayload, updateExpiryParams: updateExpiryParams)
-            default:
-                return
+        networkingInteractor.wcRequestPublisher
+            .sink { [unowned self] subscriptionPayload in
+                do {
+                    switch subscriptionPayload.wcRequest.params {
+                    case .sessionUpdate(let updateParams):
+                        try onSessionUpdateNamespacesRequest(payload: subscriptionPayload, updateParams: updateParams)
+                    case .sessionExtend(let updateExpiryParams):
+                        try onSessionUpdateExpiry(subscriptionPayload, updateExpiryParams: updateExpiryParams)
+                    default: return
+                    }
+                } catch Errors.respondError(let payload, let reason) {
+                    respondError(payload: payload, reason: reason)
+                } catch {
+                    logger.error("Unexpected Error: \(error.localizedDescription)")
+                }
+            }.store(in: &publishers)
+    }
+    
+    private func respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode) {
+        Task {
+            do {
+                try await self.networkingInteractor.respondError(payload: payload, reason: reason)
+            } catch {
+                self.logger.error("Respond Error: \(error.localizedDescription)")
             }
-        }.store(in: &publishers)
+        }
     }
     
     // TODO: Update stored session namespaces
-    private func onSessionUpdateNamespacesRequest(payload: WCRequestSubscriptionPayload, updateParams: SessionType.UpdateParams) {
+    private func onSessionUpdateNamespacesRequest(payload: WCRequestSubscriptionPayload, updateParams: SessionType.UpdateParams) throws {
         do {
             try Namespace.validate(updateParams.namespaces)
         } catch {
-            networkingInteractor.respondError(for: payload, reason: .invalidUpdateNamespaceRequest)
-            return
+            throw Errors.respondError(payload: payload, reason: .invalidUpdateNamespaceRequest)
         }
         guard var session = sessionStore.getSession(forTopic: payload.topic) else {
-            networkingInteractor.respondError(for: payload, reason: .noContextWithTopic(context: .session, topic: payload.topic))
-            return
+            throw Errors.respondError(payload: payload, reason: .noContextWithTopic(context: .session, topic: payload.topic))
         }
         guard session.peerIsController else {
-            networkingInteractor.respondError(for: payload, reason: .unauthorizedUpdateNamespacesRequest)
-            return
+            throw Errors.respondError(payload: payload, reason: .unauthorizedUpdateNamespacesRequest)
         }
         session.updateNamespaces(updateParams.namespaces)
         sessionStore.setSession(session)
@@ -61,22 +77,18 @@ final class NonControllerSessionStateMachine {
         onNamespacesUpdate?(session.topic, updateParams.namespaces)
     }
 
-    private func onSessionUpdateExpiry(_ payload: WCRequestSubscriptionPayload, updateExpiryParams: SessionType.UpdateExpiryParams) {
+    private func onSessionUpdateExpiry(_ payload: WCRequestSubscriptionPayload, updateExpiryParams: SessionType.UpdateExpiryParams) throws {
         let topic = payload.topic
         guard var session = sessionStore.getSession(forTopic: topic) else {
-            networkingInteractor.respondError(for: payload, reason: .noContextWithTopic(context: .session, topic: topic))
-            return
+            throw Errors.respondError(payload: payload, reason: .noContextWithTopic(context: .session, topic: topic))
         }
         guard session.peerIsController else {
-            networkingInteractor.respondError(for: payload, reason: .unauthorizedUpdateExpiryRequest)
-            return
+            throw Errors.respondError(payload: payload, reason: .unauthorizedUpdateExpiryRequest)
         }
         do {
             try session.updateExpiry(to: updateExpiryParams.expiry)
         } catch {
-            print(error)
-            networkingInteractor.respondError(for: payload, reason: .invalidUpdateExpiryRequest)
-            return
+            throw Errors.respondError(payload: payload, reason: .invalidUpdateExpiryRequest)
         }
         sessionStore.setSession(session)
         networkingInteractor.respondSuccess(for: payload)

--- a/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
+++ b/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
@@ -11,7 +11,7 @@ final class NonControllerSessionStateMachine {
 
     var onNamespacesUpdate: ((String, [String: SessionNamespace])->())?
     var onExtend: ((String, Date) -> ())?
-    
+
     private let sessionStore: WCSessionStorage
     private let networkingInteractor: NetworkInteracting
     private let kms: KeyManagementServiceProtocol

--- a/Sources/WalletConnectSign/JsonRpcHistory/JsonRpcHistory.swift
+++ b/Sources/WalletConnectSign/JsonRpcHistory/JsonRpcHistory.swift
@@ -29,7 +29,7 @@ class JsonRpcHistory: JsonRpcHistoryRecording {
         }
         logger.debug("Setting JSON-RPC request history record - ID: \(request.id)")
         let record = JsonRpcRecord(id: request.id, topic: topic, request: JsonRpcRecord.Request(method: request.method, params: request.params), response: nil, chainId: chainId)
-        try storage.set(record, forKey: "\(request.id)")
+        storage.set(record, forKey: "\(request.id)")
     }
     
     func delete(topic: String) {
@@ -49,7 +49,7 @@ class JsonRpcHistory: JsonRpcHistoryRecording {
             throw WalletConnectError.internal(.jsonRpcDuplicateDetected)
         } else {
             record.response = response
-            try storage.set(record, forKey: "\(record.id)")
+            storage.set(record, forKey: "\(record.id)")
             return record
         }
     }

--- a/Sources/WalletConnectSign/Namespace.swift
+++ b/Sources/WalletConnectSign/Namespace.swift
@@ -59,17 +59,17 @@ enum Namespace {
     static func validate(_ namespaces: [String: ProposalNamespace]) throws {
         for (key, namespace) in namespaces {
             if namespace.chains.isEmpty {
-                throw WalletConnectError.namespaceHasEmptyChains
+                throw WalletConnectError.unsupportedNamespace(.unsupportedChains)
             }
             for chain in namespace.chains {
                 if key != chain.namespace {
-                    throw WalletConnectError.invalidNamespace
+                    throw WalletConnectError.unsupportedNamespace(.unsupportedChains)
                 }
             }
             if let extensions = namespace.extensions {
                 for ext in extensions {
                     if ext.chains.isEmpty {
-                        throw WalletConnectError.namespaceHasEmptyChains
+                        throw WalletConnectError.unsupportedNamespace(.unsupportedChains)
                     }
                 }
             }
@@ -79,17 +79,17 @@ enum Namespace {
     static func validate(_ namespaces: [String: SessionNamespace]) throws {
         for (key, namespace) in namespaces {
             if namespace.accounts.isEmpty {
-                throw WalletConnectError.invalidNamespace
+                throw WalletConnectError.unsupportedNamespace(.unsupportedAccounts)
             }
             for account in namespace.accounts {
                 if key != account.namespace {
-                    throw WalletConnectError.invalidNamespace
+                    throw WalletConnectError.unsupportedNamespace(.unsupportedAccounts)
                 }
             }
             if let extensions = namespace.extensions {
                 for ext in extensions {
                     if ext.accounts.isEmpty {
-                        throw WalletConnectError.invalidNamespace
+                        throw WalletConnectError.unsupportedNamespace(.unsupportedAccounts)
                     }
                 }
             }
@@ -102,21 +102,21 @@ enum Namespace {
     ) throws {
         for (key, proposedNamespace) in proposalNamespaces {
             guard let approvedNamespace = sessionNamespaces[key] else {
-                throw WalletConnectError.invalidNamespaceMatch
+                throw WalletConnectError.unsupportedNamespace(.unsupportedNamespaceKey)
             }
             try proposedNamespace.chains.forEach { chain in
                 if !approvedNamespace.accounts.contains(where: { $0.blockchain == chain }) {
-                    throw WalletConnectError.invalidNamespaceMatch
+                    throw WalletConnectError.unsupportedNamespace(.unsupportedChains)
                 }
             }
             try proposedNamespace.methods.forEach {
                 if !approvedNamespace.methods.contains($0) {
-                    throw WalletConnectError.invalidNamespaceMatch
+                    throw WalletConnectError.unsupportedNamespace(.unsupportedMethods)
                 }
             }
             try proposedNamespace.events.forEach {
                 if !approvedNamespace.events.contains($0) {
-                    throw WalletConnectError.invalidNamespaceMatch
+                    throw WalletConnectError.unsupportedNamespace(.unsupportedEvents)
                 }
             }
         }

--- a/Sources/WalletConnectSign/NetworkInteractor/NetworkInteractor.swift
+++ b/Sources/WalletConnectSign/NetworkInteractor/NetworkInteractor.swift
@@ -161,7 +161,14 @@ class NetworkInteractor: NetworkInteracting {
     
     // TODO: Move to async
     func respondSuccess(for payload: WCRequestSubscriptionPayload) {
-        Task { try? await respondSuccess(payload: payload) }
+        Task {
+            do {
+                try await respondSuccess(payload: payload)
+            } catch {
+                self.logger.error("Respond Success failed with: \(error.localizedDescription)")
+            }
+        }
+        
     }
     
     func subscribe(topic: String) async throws {

--- a/Sources/WalletConnectSign/NetworkInteractor/NetworkInteractor.swift
+++ b/Sources/WalletConnectSign/NetworkInteractor/NetworkInteractor.swift
@@ -26,7 +26,6 @@ protocol NetworkInteracting: AnyObject {
     func respondSuccess(payload: WCRequestSubscriptionPayload) async throws
     func respondSuccess(for payload: WCRequestSubscriptionPayload)
     func respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode) async throws
-    func respondError(for payload: WCRequestSubscriptionPayload, reason: ReasonCode)
     func subscribe(topic: String) async throws
     func unsubscribe(topic: String)
 }
@@ -163,11 +162,6 @@ class NetworkInteractor: NetworkInteracting {
     // TODO: Move to async
     func respondSuccess(for payload: WCRequestSubscriptionPayload) {
         Task { try? await respondSuccess(payload: payload) }
-    }
-    
-    // TODO: Move to async
-    func respondError(for payload: WCRequestSubscriptionPayload, reason: ReasonCode) {
-        Task { try? await respondError(payload: payload, reason: reason) }
     }
     
     func subscribe(topic: String) async throws {

--- a/Sources/WalletConnectSign/Sign/Sign.swift
+++ b/Sources/WalletConnectSign/Sign/Sign.swift
@@ -149,16 +149,16 @@ extension Sign {
     ///   - accounts: A Set of accounts that the dapp will be allowed to request methods executions on.
     ///   - methods: A Set of methods that the dapp will be allowed to request.
     ///   - events: A Set of events
-    public func approve(proposalId: String, namespaces: [String : SessionNamespace]) throws {
-        try client.approve(proposalId: proposalId, namespaces: namespaces)
+    public func approve(proposalId: String, namespaces: [String : SessionNamespace]) async throws {
+        try await client.approve(proposalId: proposalId, namespaces: namespaces)
     }
 
     /// For the responder to reject a session proposal.
     /// - Parameters:
     ///   - proposalId: Session Proposal Public key received from peer client in a WalletConnect delegate.
     ///   - reason: Reason why the session proposal was rejected. Conforms to CAIP25.
-    public func reject(proposalId: String, reason: RejectionReason) throws {
-        try client.reject(proposalId: proposalId, reason: reason)
+    public func reject(proposalId: String, reason: RejectionReason) async throws {
+        try await client.reject(proposalId: proposalId, reason: reason)
     }
 
     /// For the responder to update session methods
@@ -188,8 +188,8 @@ extension Sign {
     /// - Parameters:
     ///   - topic: Topic of the session for which the request was received.
     ///   - response: Your JSON RPC response or an error.
-    public func respond(topic: String, response: JsonRpcResult) {
-        client.respond(topic: topic, response: response)
+    public func respond(topic: String, response: JsonRpcResult) async throws {
+        try await client.respond(topic: topic, response: response)
     }
 
     /// Ping method allows to check if client's peer is online and is subscribing for your sequence topic

--- a/Sources/WalletConnectSign/Sign/SignClient.swift
+++ b/Sources/WalletConnectSign/Sign/SignClient.swift
@@ -159,17 +159,17 @@ public final class SignClient {
     ///   - accounts: A Set of accounts that the dapp will be allowed to request methods executions on.
     ///   - methods: A Set of methods that the dapp will be allowed to request.
     ///   - events: A Set of events
-    public func approve(proposalId: String, namespaces: [String: SessionNamespace]) throws {
+    public func approve(proposalId: String, namespaces: [String: SessionNamespace]) async throws {
         //TODO - accounts should be validated for matching namespaces BEFORE responding proposal
-        try approveEngine.approveProposal(proposerPubKey: proposalId, validating: namespaces)
+        try await approveEngine.approveProposal(proposerPubKey: proposalId, validating: namespaces)
     }
     
     /// For the responder to reject a session proposal.
     /// - Parameters:
     ///   - proposalId: Session Proposal Public key received from peer client in a WalletConnect delegate.
     ///   - reason: Reason why the session proposal was rejected. Conforms to CAIP25.
-    public func reject(proposalId: String, reason: RejectionReason) throws {
-        try approveEngine.reject(proposerPubKey: proposalId, reason: reason.internalRepresentation())
+    public func reject(proposalId: String, reason: RejectionReason) async throws {
+        try await approveEngine.reject(proposerPubKey: proposalId, reason: reason.internalRepresentation())
     }
     
     /// For the responder to update session namespaces
@@ -202,8 +202,8 @@ public final class SignClient {
     /// - Parameters:
     ///   - topic: Topic of the session for which the request was received.
     ///   - response: Your JSON RPC response or an error.
-    public func respond(topic: String, response: JsonRpcResult) {
-        sessionEngine.respondSessionRequest(topic: topic, response: response)
+    public func respond(topic: String, response: JsonRpcResult) async throws {
+        try await sessionEngine.respondSessionRequest(topic: topic, response: response)
     }
     
     /// Ping method allows to check if client's peer is online and is subscribing for your sequence topic

--- a/Sources/WalletConnectSign/Types/ReasonCode.swift
+++ b/Sources/WalletConnectSign/Types/ReasonCode.swift
@@ -28,6 +28,11 @@ enum ReasonCode {
     case disapprovedChains
     case disapprovedMethods
     case disapprovedEventTypes
+    case unsupportedChains
+    case unsupportedMethods
+    case unsupportedEvents
+    case unsupportedAccounts
+    case unsupportedNamespaceKey
     
     var code: Int {
         switch self {
@@ -50,6 +55,12 @@ enum ReasonCode {
         case .disapprovedChains: return 5000
         case .disapprovedMethods: return 5001
         case .disapprovedEventTypes: return 5002
+            
+        case .unsupportedChains: return 5100
+        case .unsupportedMethods: return 5101
+        case .unsupportedEvents: return 5102
+        case .unsupportedAccounts: return 5103
+        case .unsupportedNamespaceKey: return 5104
         }
     }
     
@@ -87,6 +98,16 @@ enum ReasonCode {
             return "User disapproved requested json-rpc methods"
         case .disapprovedEventTypes:
             return "User disapproved requested event types"
+        case .unsupportedChains:
+            return "Unsupported or empty chains for namespace"
+        case .unsupportedMethods:
+            return "Unsupported methods for namespace"
+        case .unsupportedEvents:
+            return "Unsupported events for namespace"
+        case .unsupportedAccounts:
+            return "Unsupported or empty accounts for namespace"
+        case .unsupportedNamespaceKey:
+            return "Unsupported namespace key"
         }
     }
 }

--- a/Sources/WalletConnectSign/WalletConnectError.swift
+++ b/Sources/WalletConnectSign/WalletConnectError.swift
@@ -6,16 +6,14 @@ enum WalletConnectError: Error {
     case noSessionMatchingTopic(String)
     case sessionNotAcknowledged(String)
     case pairingNotSettled(String)
-    case invalidNamespace
-    case namespaceHasEmptyChains
     case invalidMethod
     case invalidEvent
     case invalidUpdateExpiryValue
     case unauthorizedNonControllerCall
     case pairingAlreadyExist
     case topicGenerationFailed
-    case invalidNamespaceMatch // TODO: Refactor into actual cases
-    case invalidPermissions // TODO: Same
+    case invalidPermissions // TODO: Refactor into actual cases
+    case unsupportedNamespace(ReasonCode)
     
     case `internal`(_ reason: InternalReason)
     
@@ -43,10 +41,6 @@ extension WalletConnectError {
             return "Pairing is not settled on topic \(topic)."
         case .invalidUpdateExpiryValue:
             return "Update expiry time is out of expected range"
-        case .invalidNamespace:
-            return "Namespace structure is invalid."
-        case .namespaceHasEmptyChains:
-            return "Namespace has an empty list of chain IDs."
         case .invalidMethod:
             return "Methods set is invalid."
         case .invalidEvent:
@@ -57,10 +51,10 @@ extension WalletConnectError {
             return "Failed to generate topic from random bytes."
         case .pairingAlreadyExist:
             return "Pairing already exist"
-        case .invalidNamespaceMatch:
-            return "Invalid namespace approval."
         case .invalidPermissions:
             return "Invalid permissions for call."
+        case .unsupportedNamespace(let reason):
+            return reason.message
         case .internal(_): // TODO: Remove internal case
             return ""
         }

--- a/Sources/WalletConnectUtils/Extensions/String.swift
+++ b/Sources/WalletConnectUtils/Extensions/String.swift
@@ -1,5 +1,3 @@
-
-
 import Foundation
 
 public extension String {
@@ -12,7 +10,7 @@ public extension String {
         return keyData.toHexString()
     }
     
-    public init<D>(rawRepresentation data: D) throws where D : ContiguousBytes {
+    init<D>(rawRepresentation data: D) throws where D : ContiguousBytes {
         let bytes = data.withUnsafeBytes { Data(Array($0)) }
         guard let string = String(data: bytes, encoding: .utf8) else {
             fatalError() // FIXME: Throw error
@@ -20,7 +18,7 @@ public extension String {
         self = string
     }
     
-    public var rawRepresentation: Data {
+    var rawRepresentation: Data {
         self.data(using: .utf8) ?? Data()
     }
 }

--- a/Sources/WalletConnectUtils/JsonRpcHistory.swift
+++ b/Sources/WalletConnectUtils/JsonRpcHistory.swift
@@ -24,7 +24,7 @@ public class JsonRpcHistory<T> where T: Codable&Equatable {
         }
         logger.debug("Setting JSON-RPC request history record")
         let record = JsonRpcRecord(id: request.id, topic: topic, request: JsonRpcRecord.Request(method: request.method, params: AnyCodable(request.params)), response: nil, chainId: chainId)
-        try storage.set(record, forKey: "\(request.id)")
+        storage.set(record, forKey: "\(request.id)")
     }
     
     public func delete(topic: String) {
@@ -44,7 +44,7 @@ public class JsonRpcHistory<T> where T: Codable&Equatable {
             throw RecordingError.jsonRpcDuplicateDetected
         } else {
             record.response = response
-            try storage.set(record, forKey: "\(record.id)")
+            storage.set(record, forKey: "\(record.id)")
             return record
         }
     }

--- a/Tests/RelayerTests/Mocks/DispatcherMock.swift
+++ b/Tests/RelayerTests/Mocks/DispatcherMock.swift
@@ -11,6 +11,9 @@ class DispatcherMock: Dispatching {
     func send(_ string: String, completion: @escaping (Error?) -> ()) {
         sent = true
     }
+    func send(_ string: String) async throws {
+        send(string, completion: { _ in })
+    }
     func connect() {}
     func disconnect(closeCode: URLSessionWebSocketTask.CloseCode) {}
 }

--- a/Tests/WalletConnectSignTests/BlockchainTests.swift
+++ b/Tests/WalletConnectSignTests/BlockchainTests.swift
@@ -30,7 +30,7 @@ final class BlockchainTests: XCTestCase {
         let blockchain = Blockchain(chainString)!
         XCTAssertEqual(blockchain.absoluteString, chainString)
     }
-    
+
     func testCodable() throws {
         let blockchain = Blockchain("chainstd:8c3444cf8970a9e41a706fab93e7a6c4")!
         let encoded = try JSONEncoder().encode(blockchain)

--- a/Tests/WalletConnectSignTests/Mocks/MockedRelay.swift
+++ b/Tests/WalletConnectSignTests/Mocks/MockedRelay.swift
@@ -67,16 +67,12 @@ class NetworkingInteractorMock: NetworkInteracting {
     }
     
     func respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode) async throws {
-        respondError(for: payload, reason: reason)
+        lastErrorCode = reason.code
+        didRespondError = true
     }
     
     func respondSuccess(for payload: WCRequestSubscriptionPayload) {
         didRespondSuccess = true
-    }
-    
-    func respondError(for payload: WCRequestSubscriptionPayload, reason: ReasonCode) {
-        lastErrorCode = reason.code
-        didRespondError = true
     }
     
     func subscribe(topic: String) {

--- a/Tests/WalletConnectSignTests/Mocks/MockedRelay.swift
+++ b/Tests/WalletConnectSignTests/Mocks/MockedRelay.swift
@@ -58,6 +58,18 @@ class NetworkingInteractorMock: NetworkInteracting {
         completion(error)
     }
     
+    func respond(topic: String, response: JsonRpcResult) async throws {
+        didRespondOnTopic = topic
+    }
+    
+    func respondSuccess(payload: WCRequestSubscriptionPayload) async throws {
+        respondSuccess(for: payload)
+    }
+    
+    func respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode) async throws {
+        respondError(for: payload, reason: reason)
+    }
+    
     func respondSuccess(for payload: WCRequestSubscriptionPayload) {
         didRespondSuccess = true
     }

--- a/Tests/WalletConnectSignTests/NonControllerSessionStateMachineTests.swift
+++ b/Tests/WalletConnectSignTests/NonControllerSessionStateMachineTests.swift
@@ -51,6 +51,7 @@ class NonControllerSessionStateMachineTests: XCTestCase {
 
     func testUpdateMethodPeerErrorSessionNotFound() {
         networkingInteractor.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateNamespaces(topic: ""))
+        usleep(100)
         XCTAssertFalse(networkingInteractor.didRespondSuccess)
         XCTAssertEqual(networkingInteractor.lastErrorCode, 1301)
     }
@@ -59,6 +60,7 @@ class NonControllerSessionStateMachineTests: XCTestCase {
         let session = WCSession.stub(isSelfController: true) // Peer is not a controller
         storageMock.setSession(session)
         networkingInteractor.wcRequestPublisherSubject.send(WCRequestSubscriptionPayload.stubUpdateNamespaces(topic: session.topic))
+        usleep(100)
         XCTAssertFalse(networkingInteractor.didRespondSuccess)
         XCTAssertEqual(networkingInteractor.lastErrorCode, 3004)
     }


### PR DESCRIPTION
**What changed?**

**Sample app** 
Approve / Reject calls wrapped in Tasks. Errors handled by logger

**SDK**
- Async `Approve` and `Reject` methods
- `NetworkInteractor`: Async RespondError and RespondSuccess methods
- `Dispatcher`: Async Send method
- Async callbacks for `wcRequestPublisher` subscribers
- Respond Namespace validation errors