### PR TITLE
[Wallet] State synchronisation

### DIFF
--- a/Example/DApp/Connect/ConnectViewController.swift
+++ b/Example/DApp/Connect/ConnectViewController.swift
@@ -28,9 +28,9 @@ class ConnectViewController: UIViewController, UITableViewDataSource, UITableVie
         super.viewDidLoad()
         DispatchQueue.global().async { [unowned self] in
             if let qrImage = generateQRCode(from: uriString) {
-                DispatchQueue.main.async {
-                    connectView.qrCodeView.image = qrImage
-                    connectView.copyButton.isHidden = false
+                DispatchQueue.main.async { [self] in
+                    self.connectView.qrCodeView.image = qrImage
+                    self.connectView.copyButton.isHidden = false
                 }
             }
         }

--- a/Example/ExampleApp/Wallet/WalletViewController.swift
+++ b/Example/ExampleApp/Wallet/WalletViewController.swift
@@ -271,8 +271,8 @@ extension WalletViewController {
         return settledSessions.map { session -> ActiveSessionItem in
             let app = session.peer
             return ActiveSessionItem(
-                dappName: app.name ?? "",
-                dappURL: app.url ?? "",
+                dappName: app.name ,
+                dappURL: app.url ,
                 iconURL: app.icons.first ?? "",
                 topic: session.topic)
         }

--- a/Sources/Chat/Types/ChatRequestParams.swift
+++ b/Sources/Chat/Types/ChatRequestParams.swift
@@ -7,7 +7,7 @@ enum ChatRequestParams: Codable, Equatable {
 }
 
 extension JSONRPCRequest {
-    init(id: Int64 = JSONRPCRequest.generateId(), params: T) where T == ChatRequestParams {
+    init(id: Int64 = JsonRpcID.generate(), params: T) where T == ChatRequestParams {
         var method: String!
         switch params {
         case .invite:

--- a/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
@@ -92,11 +92,11 @@ final class ApproveEngine {
         }
         proposalPayloadsStore.delete(forKey: proposerPubKey)
         try await networkingInteractor.respondError(payload: payload, reason: reason)
-        // TODO: Delete pairing if inactive
+        // TODO: Delete pairing if inactive 
     }
 
     func settle(topic: String, proposal: SessionProposal, namespaces: [String: SessionNamespace]) async throws {
-        guard let agreementKeys = try kms.getAgreementSecret(for: topic) else {
+        guard let agreementKeys = kms.getAgreementSecret(for: topic) else {
             throw Errors.agreementMissingOrInvalid
         }
         let selfParticipant = Participant(
@@ -120,6 +120,7 @@ final class ApproveEngine {
 
         let session = WCSession(
             topic: topic,
+            timestamp: Date(),
             selfParticipant: selfParticipant,
             peerParticipant: proposal.proposer,
             settleParams: settleParams,
@@ -294,7 +295,7 @@ private extension ApproveEngine {
         }
 
         let topic = payload.topic
-        let agreementKeys = try kms.getAgreementSecret(for: topic)!
+        let agreementKeys = kms.getAgreementSecret(for: topic)!
         let selfParticipant = Participant(
             publicKey: agreementKeys.publicKey.hexRepresentation,
             metadata: metadata
@@ -305,6 +306,7 @@ private extension ApproveEngine {
 
         let session = WCSession(
             topic: topic,
+            timestamp: Date(),
             selfParticipant: selfParticipant,
             peerParticipant: settleParams.controller,
             settleParams: settleParams,

--- a/Sources/WalletConnectSign/Engine/Controller/ControllerSessionStateMachine.swift
+++ b/Sources/WalletConnectSign/Engine/Controller/ControllerSessionStateMachine.swift
@@ -50,42 +50,46 @@ final class ControllerSessionStateMachine {
 
     private func handleResponse(_ response: WCResponse) {
         switch response.requestParams {
-        case .sessionUpdate:
-            handleUpdateResponse(topic: response.topic, result: response.result)
-        case .sessionExtend:
-            handleUpdateExpiryResponse(topic: response.topic, result: response.result)
+        case .sessionUpdate(let payload):
+            handleUpdateResponse(response: response, payload: payload)
+        case .sessionExtend(let payload):
+            handleUpdateExpiryResponse(response: response, payload: payload)
         default:
             break
         }
     }
 
-    // TODO: Re-enable callback
-    private func handleUpdateResponse(topic: String, result: JsonRpcResult) {
-        guard let _ = sessionStore.getSession(forTopic: topic) else {
-            return
-        }
-        switch result {
+    private func handleUpdateResponse(response: WCResponse, payload: SessionType.UpdateParams) {
+        guard var session = sessionStore.getSession(forTopic: response.topic) else { return }
+        switch response.result {
         case .response:
-            // TODO - state sync
-//            onNamespacesUpdate?(session.topic, session.namespaces)
-            break
+            do {
+                try session.updateNamespaces(payload.namespaces, timestamp: response.timestamp)
+
+                if sessionStore.setSessionIfNewer(session) {
+                    onNamespacesUpdate?(session.topic, session.namespaces)
+                }
+            } catch {
+                logger.error("Update namespaces error: \(error.localizedDescription)")
+            }
         case .error:
-            // TODO - state sync
-            logger.error("Peer failed to update methods.")
+            logger.error("Peer failed to update session")
         }
     }
 
-    private func handleUpdateExpiryResponse(topic: String, result: JsonRpcResult) {
-        guard let session = sessionStore.getSession(forTopic: topic) else {
-            return
-        }
-        switch result {
+    private func handleUpdateExpiryResponse(response: WCResponse, payload: SessionType.UpdateExpiryParams) {
+        guard var session = sessionStore.getSession(forTopic: response.topic) else { return }
+        switch response.result {
         case .response:
-            // TODO - state sync
-            onExtend?(session.topic, session.expiryDate)
+            do {
+                try session.updateExpiry(to: payload.expiry)
+                sessionStore.setSession(session)
+                onExtend?(session.topic, session.expiryDate)
+            } catch {
+                logger.error("Update expiry error: \(error.localizedDescription)")
+            }
         case .error:
-            // TODO - state sync
-            logger.error("Peer failed to update events.")
+            logger.error("Peer failed to extend session")
         }
     }
 

--- a/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
+++ b/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
@@ -71,7 +71,7 @@ final class NonControllerSessionStateMachine {
             throw Errors.respondError(payload: payload, reason: .unauthorizedUpdateNamespacesRequest)
         }
         do {
-            try session.updateNamespaces(updateParams.namespaces)
+            try session.updateNamespaces(updateParams.namespaces, timestamp: payload.timestamp)
         } catch {
             throw Errors.respondError(payload: payload, reason: .invalidUpdateNamespaceRequest)
         }

--- a/Sources/WalletConnectSign/Namespace.swift
+++ b/Sources/WalletConnectSign/Namespace.swift
@@ -44,7 +44,7 @@ public struct SessionNamespace: Equatable, Codable {
             self.methods = methods
             self.events = events
         }
-        
+
         func isSuperset(of other: Extension) -> Bool {
             self.accounts.isSuperset(of: other.accounts) &&
             self.methods.isSuperset(of: other.methods) &&

--- a/Sources/WalletConnectSign/NetworkInteractor/NetworkInteractor.swift
+++ b/Sources/WalletConnectSign/NetworkInteractor/NetworkInteractor.swift
@@ -3,14 +3,6 @@ import Combine
 import WalletConnectUtils
 import WalletConnectKMS
 
-struct WCResponse: Codable {
-    let topic: String
-    let chainId: String?
-    let requestMethod: WCRequest.Method
-    let requestParams: WCRequest.Params
-    let result: JsonRpcResult
-}
-
 protocol NetworkInteracting: AnyObject {
     var transportConnectionPublisher: AnyPublisher<Void, Never> {get}
     var wcRequestPublisher: AnyPublisher<WCRequestSubscriptionPayload, Never> {get}

--- a/Sources/WalletConnectSign/Request.swift
+++ b/Sources/WalletConnectSign/Request.swift
@@ -17,14 +17,10 @@ public struct Request: Codable, Equatable {
     }
 
     public init(topic: String, method: String, params: AnyCodable, chainId: Blockchain) {
-        self.id = Self.generateId()
+        self.id = JsonRpcID.generate()
         self.topic = topic
         self.method = method
         self.params = params
         self.chainId = chainId
-    }
-
-    public static func generateId() -> Int64 {
-        return Int64(Date().timeIntervalSince1970 * 1000)*1000 + Int64.random(in: 0..<1000)
     }
 }

--- a/Sources/WalletConnectSign/Storage/SequenceStore.swift
+++ b/Sources/WalletConnectSign/Storage/SequenceStore.swift
@@ -5,12 +5,13 @@ protocol Expirable {
     var expiryDate: Date { get }
 }
 
-protocol ExpirableSequence: Codable, Expirable {
+protocol Entitled {
     var topic: String { get }
 }
 
-// TODO: Find replacement for 'Sequence' prefix
-final class SequenceStore<T> where T: ExpirableSequence {
+typealias SequenceObject = Entitled & Expirable & Codable
+
+final class SequenceStore<T> where T: SequenceObject {
 
     var onSequenceExpiration: ((_ sequence: T) -> Void)?
 
@@ -47,8 +48,13 @@ final class SequenceStore<T> where T: ExpirableSequence {
     func deleteAll() {
         store.deleteAll()
     }
+}
 
-    private func verifyExpiry(on sequence: T) -> T? {
+// MARK: Privates
+
+private extension SequenceStore {
+
+    func verifyExpiry(on sequence: T) -> T? {
         let now = dateInitializer()
         if now >= sequence.expiryDate {
             store.delete(forKey: sequence.topic)

--- a/Sources/WalletConnectSign/Subscription/WCRequestSubscriptionPayload.swift
+++ b/Sources/WalletConnectSign/Subscription/WCRequestSubscriptionPayload.swift
@@ -1,6 +1,11 @@
 import Foundation
+import WalletConnectUtils
 
 struct WCRequestSubscriptionPayload: Codable {
     let topic: String
     let wcRequest: WCRequest
+
+    var timestamp: Date {
+        return JsonRpcID.timestamp(from: wcRequest.id)
+    }
 }

--- a/Sources/WalletConnectSign/Types/Pairing/WCPairing.swift
+++ b/Sources/WalletConnectSign/Types/Pairing/WCPairing.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WalletConnectKMS
 
-struct WCPairing: ExpirableSequence {
+struct WCPairing: SequenceObject {
     let topic: String
     let relay: RelayProtocolOptions
     var peerMetadata: AppMetadata?

--- a/Sources/WalletConnectSign/Types/Session/WCSession.swift
+++ b/Sources/WalletConnectSign/Types/Session/WCSession.swift
@@ -2,8 +2,7 @@ import Foundation
 import WalletConnectKMS
 import WalletConnectUtils
 
-struct WCSession: ExpirableSequence {
-
+struct WCSession: SequenceObject, Equatable {
     enum Error: Swift.Error {
         case controllerNotSet
         case unsatisfiedUpdateNamespaceRequirement
@@ -13,9 +12,11 @@ struct WCSession: ExpirableSequence {
     let relay: RelayProtocolOptions
     let selfParticipant: Participant
     let peerParticipant: Participant
-    private (set) var expiryDate: Date
-    var acknowledged: Bool
     let controller: AgreementPeer
+
+    private(set) var acknowledged: Bool
+    private(set) var expiryDate: Date
+    private(set) var timestamp: Date
     private(set) var namespaces: [String: SessionNamespace]
     private(set) var requiredNamespaces: [String: SessionNamespace]
 
@@ -28,11 +29,13 @@ struct WCSession: ExpirableSequence {
     }
 
     init(topic: String,
+         timestamp: Date,
          selfParticipant: Participant,
          peerParticipant: Participant,
          settleParams: SessionType.SettleParams,
          acknowledged: Bool) {
         self.topic = topic
+        self.timestamp = timestamp
         self.relay = settleParams.relay
         self.controller = AgreementPeer(publicKey: settleParams.controller.publicKey)
         self.selfParticipant = selfParticipant
@@ -44,8 +47,9 @@ struct WCSession: ExpirableSequence {
     }
 
 #if DEBUG
-    internal init(topic: String, relay: RelayProtocolOptions, controller: AgreementPeer, selfParticipant: Participant, peerParticipant: Participant, namespaces: [String: SessionNamespace], events: Set<String>, accounts: Set<Account>, acknowledged: Bool, expiry: Int64) {
+    internal init(topic: String, timestamp: Date, relay: RelayProtocolOptions, controller: AgreementPeer, selfParticipant: Participant, peerParticipant: Participant, namespaces: [String: SessionNamespace], events: Set<String>, accounts: Set<Account>, acknowledged: Bool, expiry: Int64) {
         self.topic = topic
+        self.timestamp = timestamp
         self.relay = relay
         self.controller = controller
         self.selfParticipant = selfParticipant
@@ -113,7 +117,7 @@ struct WCSession: ExpirableSequence {
         return false
     }
 
-    mutating func updateNamespaces(_ namespaces: [String: SessionNamespace]) throws {
+    mutating func updateNamespaces(_ namespaces: [String: SessionNamespace], timestamp: Date = Date()) throws {
         for item in requiredNamespaces {
             guard
                 let compliantNamespace = namespaces[item.key],
@@ -135,6 +139,7 @@ struct WCSession: ExpirableSequence {
             }
         }
         self.namespaces = namespaces
+        self.timestamp = timestamp
     }
 
     /// updates session expiry by given ttl
@@ -145,7 +150,7 @@ struct WCSession: ExpirableSequence {
         guard newExpiryDate > expiryDate && newExpiryDate <= maxExpiryDate else {
             throw WalletConnectError.invalidUpdateExpiryValue
         }
-        expiryDate = newExpiryDate
+        self.expiryDate = newExpiryDate
     }
 
     /// updates session expiry to given timestamp
@@ -156,7 +161,7 @@ struct WCSession: ExpirableSequence {
         guard newExpiryDate > expiryDate && newExpiryDate <= maxExpiryDate else {
             throw WalletConnectError.invalidUpdateExpiryValue
         }
-        expiryDate = newExpiryDate
+        self.expiryDate = newExpiryDate
     }
 
     func publicRepresentation() -> Session {
@@ -165,5 +170,44 @@ struct WCSession: ExpirableSequence {
             peer: peerParticipant.metadata,
             namespaces: namespaces,
             expiryDate: expiryDate)
+    }
+}
+
+// MARK: Codable Migration
+
+extension WCSession {
+
+    enum CodingKeys: String, CodingKey {
+        case topic, relay, selfParticipant, peerParticipant, expiryDate, acknowledged, controller, namespaces, timestamp, requiredNamespaces
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.topic = try container.decode(String.self, forKey: .topic)
+        self.relay = try container.decode(RelayProtocolOptions.self, forKey: .relay)
+        self.controller = try container.decode(AgreementPeer.self, forKey: .controller)
+        self.selfParticipant = try container.decode(Participant.self, forKey: .selfParticipant)
+        self.peerParticipant = try container.decode(Participant.self, forKey: .peerParticipant)
+        self.namespaces = try container.decode([String: SessionNamespace].self, forKey: .namespaces)
+        self.acknowledged = try container.decode(Bool.self, forKey: .acknowledged)
+        self.expiryDate = try container.decode(Date.self, forKey: .expiryDate)
+
+        // Migration beta.102
+        self.timestamp = try container.decodeIfPresent(Date.self, forKey: .timestamp) ?? .distantPast
+        self.requiredNamespaces = try container.decodeIfPresent([String: SessionNamespace].self, forKey: .requiredNamespaces) ?? [:]
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(topic, forKey: .topic)
+        try container.encode(relay, forKey: .relay)
+        try container.encode(controller, forKey: .controller)
+        try container.encode(selfParticipant, forKey: .selfParticipant)
+        try container.encode(peerParticipant, forKey: .peerParticipant)
+        try container.encode(namespaces, forKey: .namespaces)
+        try container.encode(acknowledged, forKey: .acknowledged)
+        try container.encode(expiryDate, forKey: .expiryDate)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(requiredNamespaces, forKey: .requiredNamespaces)
     }
 }

--- a/Sources/WalletConnectSign/Types/WCRequest.swift
+++ b/Sources/WalletConnectSign/Types/WCRequest.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WalletConnectUtils
 
 struct WCRequest: Codable {
     let id: Int64
@@ -13,7 +14,7 @@ struct WCRequest: Codable {
         case params
     }
 
-    internal init(id: Int64 = generateId(), jsonrpc: String = "2.0", method: Method, params: Params) {
+    internal init(id: Int64 = JsonRpcID.generate(), jsonrpc: String = "2.0", method: Method, params: Params) {
         self.id = id
         self.jsonrpc = jsonrpc
         self.method = method
@@ -87,11 +88,6 @@ struct WCRequest: Codable {
             try container.encode(params, forKey: .params)
         }
     }
-
-    private static func generateId() -> Int64 {
-        return Int64(Date().timeIntervalSince1970 * 1000)*1000 + Int64.random(in: 0..<1000)
-    }
-
 }
 
 extension WCRequest {

--- a/Sources/WalletConnectSign/Types/WCResponse.swift
+++ b/Sources/WalletConnectSign/Types/WCResponse.swift
@@ -1,0 +1,14 @@
+import Foundation
+import WalletConnectUtils
+
+struct WCResponse: Codable {
+    let topic: String
+    let chainId: String?
+    let requestMethod: WCRequest.Method
+    let requestParams: WCRequest.Params
+    let result: JsonRpcResult
+
+    var timestamp: Date {
+        return JsonRpcID.timestamp(from: result.id)
+    }
+}

--- a/Sources/WalletConnectUtils/JSONRPC/JSONRPCRequest.swift
+++ b/Sources/WalletConnectUtils/JSONRPC/JSONRPCRequest.swift
@@ -1,5 +1,3 @@
-// 
-
 import Foundation
 
 public struct JSONRPCRequest<T: Codable&Equatable>: Codable, Equatable {
@@ -16,14 +14,10 @@ public struct JSONRPCRequest<T: Codable&Equatable>: Codable, Equatable {
         case params
     }
 
-    public init(id: Int64 = JSONRPCRequest.generateId(), method: String, params: T) {
+    public init(id: Int64 = JsonRpcID.generate(), method: String, params: T) {
         self.id = id
         self.jsonrpc = "2.0"
         self.method = method
         self.params = params
-    }
-
-    public static func generateId() -> Int64 {
-        return Int64(Date().timeIntervalSince1970 * 1000)*1000 + Int64.random(in: 0..<1000)
     }
 }

--- a/Sources/WalletConnectUtils/JSONRPC/JsonRpcResult.swift
+++ b/Sources/WalletConnectUtils/JSONRPC/JsonRpcResult.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum JsonRpcResult: Codable {
     case error(JSONRPCErrorResponse)
     case response(JSONRPCResponse<AnyCodable>)
+
     public var id: Int64 {
         switch self {
         case .error(let value):
@@ -11,6 +12,7 @@ public enum JsonRpcResult: Codable {
             return value.id
         }
     }
+
     public var value: Codable {
         switch self {
         case .error(let value):

--- a/Sources/WalletConnectUtils/JsonRecID.swift
+++ b/Sources/WalletConnectUtils/JsonRecID.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct JsonRpcID {
+
+    public static func generate() -> Int64 {
+        let timestamp = Int64(Date().timeIntervalSince1970 * 1000) * 1000
+        let random = Int64.random(in: 0..<1000)
+        return timestamp + random
+    }
+
+    public static func timestamp(from id: Int64) -> Date {
+        let interval = TimeInterval(id / 1000 / 1000)
+        return Date(timeIntervalSince1970: interval)
+    }
+}

--- a/Tests/WalletConnectSignTests/Mocks/WCSessionStorageMock.swift
+++ b/Tests/WalletConnectSignTests/Mocks/WCSessionStorageMock.swift
@@ -2,12 +2,20 @@
 import Foundation
 
 final class WCSessionStorageMock: WCSessionStorage {
+
     var onSessionExpiration: ((WCSession) -> Void)?
 
     private(set) var sessions: [String: WCSession] = [:]
 
     func hasSession(forTopic topic: String) -> Bool {
         sessions[topic] != nil
+    }
+
+    @discardableResult
+    func setSessionIfNewer(_ session: WCSession) -> Bool {
+        guard isNeedToReplace(session) else { return false }
+        sessions[session.topic] = session
+        return true
     }
 
     func setSession(_ session: WCSession) {
@@ -28,5 +36,15 @@ final class WCSessionStorageMock: WCSessionStorage {
 
     func deleteAll() {
         sessions = [:]
+    }
+}
+
+// MARK: Privates
+
+private extension WCSessionStorageMock {
+
+    func isNeedToReplace(_ session: WCSession) -> Bool {
+        guard let old = getSession(forTopic: session.topic) else { return true }
+        return session.timestamp > old.timestamp
     }
 }

--- a/Tests/WalletConnectSignTests/SequenceStoreTests.swift
+++ b/Tests/WalletConnectSignTests/SequenceStoreTests.swift
@@ -2,10 +2,22 @@ import XCTest
 import WalletConnectUtils
 @testable import WalletConnectSign
 
-struct ExpirableSequenceStub: ExpirableSequence, Equatable {
+struct ExpirableSequenceStub: SequenceObject, Equatable {
     let topic: String
     let publicKey: String?
     let expiryDate: Date
+
+    var timestamp: Date {
+        return .distantPast
+    }
+
+    func isNewer(than date: Date) -> Bool {
+        return true
+    }
+
+    func isExpired(now: Date) -> Bool {
+        return now >= expiryDate
+    }
 }
 
 final class SequenceStoreTests: XCTestCase {

--- a/Tests/WalletConnectSignTests/SessionStorageTests.swift
+++ b/Tests/WalletConnectSignTests/SessionStorageTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+@testable import WalletConnectSign
+import WalletConnectUtils
+
+final class SessionStorageTests: XCTestCase {
+
+    var sut: SessionStorage!
+
+    override func setUp() {
+        sut = SessionStorage(storage: .init(store: .init(
+            defaults: RuntimeKeyValueStorage(),
+            identifier: "")
+        ))
+    }
+
+    func testUpdateSessionFailedByTimestamp() {
+        let timestamp = Date()
+        let old = WCSession.stub(timestamp: timestamp)
+
+        XCTAssertTrue(sut.setSessionIfNewer(old))
+        XCTAssertEqual(sut.getAll(), [old])
+
+        let new = WCSession.stub(topic: old.topic, timestamp: timestamp)
+
+        XCTAssertFalse(sut.setSessionIfNewer(new))
+    }
+
+    func testUpdateSessionSucceedByTimestamp() {
+        let old = WCSession.stub(timestamp: Date())
+
+        XCTAssertTrue(sut.setSessionIfNewer(old))
+        XCTAssertEqual(sut.getAll(), [old])
+
+        let new = WCSession.stub(topic: old.topic, timestamp: Date())
+
+        XCTAssertTrue(sut.setSessionIfNewer(new))
+        XCTAssertEqual(sut.getAll(), [new])
+    }
+
+    func testSetMultipleSessions() {
+        let one = WCSession.stub()
+        let two = WCSession.stub()
+
+        XCTAssertTrue(sut.setSessionIfNewer(one))
+        XCTAssertTrue(sut.setSessionIfNewer(two))
+        XCTAssertEqual(sut.getAll().count, 2)
+    }
+}

--- a/Tests/WalletConnectSignTests/Stub/Session+Stub.swift
+++ b/Tests/WalletConnectSignTests/Stub/Session+Stub.swift
@@ -4,27 +4,30 @@ import WalletConnectKMS
 
 extension WCSession {
     static func stub(
+        topic: String = .generateTopic(),
         isSelfController: Bool = false,
         expiryDate: Date = Date.distantFuture,
         selfPrivateKey: AgreementPrivateKey = AgreementPrivateKey(),
         namespaces: [String: SessionNamespace] = [:],
-        acknowledged: Bool = true
+        acknowledged: Bool = true,
+        timestamp: Date = Date()
     ) -> WCSession {
-        let peerKey = selfPrivateKey.publicKey.hexRepresentation
-        let selfKey = AgreementPrivateKey().publicKey.hexRepresentation
-        let controllerKey = isSelfController ? selfKey : peerKey
-        return WCSession(
-            topic: String.generateTopic(),
-            relay: RelayProtocolOptions.stub(),
-            controller: AgreementPeer(publicKey: controllerKey),
-            selfParticipant: Participant.stub(publicKey: selfKey),
-            peerParticipant: Participant.stub(publicKey: peerKey),
-            namespaces: namespaces,
-            events: [],
-            accounts: Account.stubSet(),
-            acknowledged: acknowledged,
-            expiry: Int64(expiryDate.timeIntervalSince1970))
-    }
+            let peerKey = selfPrivateKey.publicKey.hexRepresentation
+            let selfKey = AgreementPrivateKey().publicKey.hexRepresentation
+            let controllerKey = isSelfController ? selfKey : peerKey
+            return WCSession(
+                topic: topic,
+                timestamp: timestamp,
+                relay: RelayProtocolOptions.stub(),
+                controller: AgreementPeer(publicKey: controllerKey),
+                selfParticipant: Participant.stub(publicKey: selfKey),
+                peerParticipant: Participant.stub(publicKey: peerKey),
+                namespaces: namespaces,
+                events: [],
+                accounts: Account.stubSet(),
+                acknowledged: acknowledged,
+                expiry: Int64(expiryDate.timeIntervalSince1970))
+        }
 }
 
 extension Account {

--- a/Tests/WalletConnectSignTests/WCResponseTests.swift
+++ b/Tests/WalletConnectSignTests/WCResponseTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import WalletConnectSign
+
+final class WCResponseTests: XCTestCase {
+
+    func testTimestamp() {
+        let request = WCRequest(
+            method: .pairingPing,
+            params: .pairingPing(.init())
+        )
+        let response = WCResponse.stubError(forRequest: request, topic: "topic")
+        let timestamp = Date(timeIntervalSince1970: TimeInterval(request.id / 1000 / 1000))
+
+        XCTAssertEqual(response.timestamp, timestamp)
+        XCTAssertTrue(Calendar.current.isDateInToday(response.timestamp))
+    }
+}

--- a/Tests/WalletConnectSignTests/WCSessionTests.swift
+++ b/Tests/WalletConnectSignTests/WCSessionTests.swift
@@ -140,7 +140,7 @@ final class WCSessionTests: XCTestCase {
     }
 
     // MARK: Namespace Update Tests
-    
+
     private func stubRequiredNamespaces() -> [String: SessionNamespace] {
         return [
             "eip155": SessionNamespace(
@@ -149,7 +149,7 @@ final class WCSessionTests: XCTestCase {
                 events: ["event", "event-2"],
                 extensions: nil)]
     }
-    
+
     private func stubRequiredNamespacesWithExtension() -> [String: SessionNamespace] {
         return [
             "eip155": SessionNamespace(
@@ -198,7 +198,7 @@ final class WCSessionTests: XCTestCase {
         var session = WCSession.stub(namespaces: stubRequiredNamespaces())
         XCTAssertThrowsError(try session.updateNamespaces([:]))
     }
-    
+
     func testUpdateLessThanRequiredAccounts() {
         let invalid = [
             "eip155": SessionNamespace(
@@ -209,7 +209,7 @@ final class WCSessionTests: XCTestCase {
         var session = WCSession.stub(namespaces: stubRequiredNamespaces())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
-    
+
     func testUpdateLessThanRequiredMethods() {
         let invalid = [
             "eip155": SessionNamespace(
@@ -220,7 +220,7 @@ final class WCSessionTests: XCTestCase {
         var session = WCSession.stub(namespaces: stubRequiredNamespaces())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
-    
+
     func testUpdateLessThanRequiredEvents() {
         let invalid = [
             "eip155": SessionNamespace(
@@ -231,7 +231,7 @@ final class WCSessionTests: XCTestCase {
         var session = WCSession.stub(namespaces: stubRequiredNamespaces())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
-    
+
     func testUpdateLessThanRequiredExtension() {
         let invalid = [
             "eip155": SessionNamespace(
@@ -242,7 +242,7 @@ final class WCSessionTests: XCTestCase {
         var session = WCSession.stub(namespaces: stubRequiredNamespacesWithExtension())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
-    
+
     func testUpdateLessThanRequiredExtensionAccounts() {
         let invalid = [
             "eip155": SessionNamespace(
@@ -257,7 +257,7 @@ final class WCSessionTests: XCTestCase {
         var session = WCSession.stub(namespaces: stubRequiredNamespacesWithExtension())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
-    
+
     func testUpdateLessThanRequiredExtensionMethods() {
         let invalid = [
             "eip155": SessionNamespace(
@@ -272,7 +272,7 @@ final class WCSessionTests: XCTestCase {
         var session = WCSession.stub(namespaces: stubRequiredNamespacesWithExtension())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
-    
+
     func testUpdateLessThanRequiredExtensionEvents() {
         let invalid = [
             "eip155": SessionNamespace(


### PR DESCRIPTION
**What changed**

- callbacks implemented in for `handleUpdateResponse` and `handleUpdateExpiryResponse`
- timestamp added to WCSession
- WCSession migration example (for timestamp)
- WCSessionStorage - isNeedToReplace logic
- ExpirableSequence renamed to SequenceObject
- SessionStorageTests