### PR TITLE
[Sign] Feature: #252 Update session namespaces checks against required namespaces

### DIFF
--- a/Sources/WalletConnectSign/Engine/Controller/ControllerSessionStateMachine.swift
+++ b/Sources/WalletConnectSign/Engine/Controller/ControllerSessionStateMachine.swift
@@ -32,7 +32,7 @@ final class ControllerSessionStateMachine {
         try validateControlledAcknowledged(session)
         try Namespace.validate(namespaces)
         logger.debug("Controller will update methods")
-        session.updateNamespaces(namespaces)
+        try session.updateNamespaces(namespaces)
         sessionStore.setSession(session)
         try await networkingInteractor.request(.wcSessionUpdate(SessionType.UpdateParams(namespaces: namespaces)), onTopic: topic)
     }

--- a/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
+++ b/Sources/WalletConnectSign/Engine/NonController/NonControllerSessionStateMachine.swift
@@ -70,7 +70,11 @@ final class NonControllerSessionStateMachine {
         guard session.peerIsController else {
             throw Errors.respondError(payload: payload, reason: .unauthorizedUpdateNamespacesRequest)
         }
-        session.updateNamespaces(updateParams.namespaces)
+        do {
+            try session.updateNamespaces(updateParams.namespaces)
+        } catch {
+            throw Errors.respondError(payload: payload, reason: .invalidUpdateNamespaceRequest)
+        }
         sessionStore.setSession(session)
         networkingInteractor.respondSuccess(for: payload)
         onNamespacesUpdate?(session.topic, updateParams.namespaces)

--- a/Sources/WalletConnectSign/Namespace.swift
+++ b/Sources/WalletConnectSign/Namespace.swift
@@ -44,6 +44,12 @@ public struct SessionNamespace: Equatable, Codable {
             self.methods = methods
             self.events = events
         }
+        
+        func isSuperset(of other: Extension) -> Bool {
+            self.accounts.isSuperset(of: other.accounts) &&
+            self.methods.isSuperset(of: other.methods) &&
+            self.events.isSuperset(of: other.events)
+        }
     }
 
     public init(accounts: Set<Account>, methods: Set<String>, events: Set<String>, extensions: [SessionNamespace.Extension]? = nil) {

--- a/Sources/WalletConnectSign/Types/Session/WCSession.swift
+++ b/Sources/WalletConnectSign/Types/Session/WCSession.swift
@@ -14,6 +14,7 @@ struct WCSession: ExpirableSequence {
     var acknowledged: Bool
     let controller: AgreementPeer
     private(set) var namespaces: [String: SessionNamespace]
+    private(set) var requiredNamespaces: [String: SessionNamespace]
 
     static var defaultTimeToLive: Int64 {
         Int64(7*Time.day)
@@ -34,6 +35,7 @@ struct WCSession: ExpirableSequence {
         self.selfParticipant = selfParticipant
         self.peerParticipant = peerParticipant
         self.namespaces = settleParams.namespaces
+        self.requiredNamespaces = settleParams.namespaces
         self.acknowledged = acknowledged
         self.expiryDate = Date(timeIntervalSince1970: TimeInterval(settleParams.expiry))
     }
@@ -46,6 +48,7 @@ struct WCSession: ExpirableSequence {
         self.selfParticipant = selfParticipant
         self.peerParticipant = peerParticipant
         self.namespaces = namespaces
+        self.requiredNamespaces = namespaces
         self.acknowledged = acknowledged
         self.expiryDate = Date(timeIntervalSince1970: TimeInterval(expiry))
     }

--- a/Sources/WalletConnectSign/Types/Session/WCSession.swift
+++ b/Sources/WalletConnectSign/Types/Session/WCSession.swift
@@ -6,7 +6,7 @@ struct WCSession: ExpirableSequence {
 
     enum Error: Swift.Error {
         case controllerNotSet
-//        case
+        case unsatisfiedUpdateNamespaceRequirement
     }
 
     let topic: String
@@ -113,7 +113,7 @@ struct WCSession: ExpirableSequence {
         return false
     }
 
-    mutating func updateNamespaces(_ namespaces: [String: SessionNamespace]) {
+    mutating func updateNamespaces(_ namespaces: [String: SessionNamespace]) throws {
         for item in requiredNamespaces {
             guard
                 let compliantNamespace = namespaces[item.key],
@@ -121,7 +121,7 @@ struct WCSession: ExpirableSequence {
                 compliantNamespace.methods.isSuperset(of: item.value.methods),
                 compliantNamespace.events.isSuperset(of: item.value.events)
             else {
-                fatalError()
+                throw Error.unsatisfiedUpdateNamespaceRequirement
             }
         }
         self.namespaces = namespaces

--- a/Sources/WalletConnectSign/Types/Session/WCSession.swift
+++ b/Sources/WalletConnectSign/Types/Session/WCSession.swift
@@ -3,9 +3,12 @@ import WalletConnectKMS
 import WalletConnectUtils
 
 struct WCSession: ExpirableSequence {
+
     enum Error: Swift.Error {
         case controllerNotSet
+//        case
     }
+
     let topic: String
     let relay: RelayProtocolOptions
     let selfParticipant: Participant
@@ -111,6 +114,16 @@ struct WCSession: ExpirableSequence {
     }
 
     mutating func updateNamespaces(_ namespaces: [String: SessionNamespace]) {
+        for item in requiredNamespaces {
+            guard
+                let compliantNamespace = namespaces[item.key],
+                compliantNamespace.accounts.isSuperset(of: item.value.accounts),
+                compliantNamespace.methods.isSuperset(of: item.value.methods),
+                compliantNamespace.events.isSuperset(of: item.value.events)
+            else {
+                fatalError()
+            }
+        }
         self.namespaces = namespaces
     }
 

--- a/Sources/WalletConnectSign/Types/Session/WCSession.swift
+++ b/Sources/WalletConnectSign/Types/Session/WCSession.swift
@@ -123,6 +123,16 @@ struct WCSession: ExpirableSequence {
             else {
                 throw Error.unsatisfiedUpdateNamespaceRequirement
             }
+            if let extensions = item.value.extensions {
+                guard let compliantExtensions = compliantNamespace.extensions else {
+                    throw Error.unsatisfiedUpdateNamespaceRequirement
+                }
+                for existingExtension in extensions {
+                    guard compliantExtensions.contains(where: { $0.isSuperset(of: existingExtension) }) else {
+                        throw Error.unsatisfiedUpdateNamespaceRequirement
+                    }
+                }
+            }
         }
         self.namespaces = namespaces
     }

--- a/Tests/WalletConnectSignTests/Stub/Session+Stub.swift
+++ b/Tests/WalletConnectSignTests/Stub/Session+Stub.swift
@@ -7,22 +7,24 @@ extension WCSession {
         isSelfController: Bool = false,
         expiryDate: Date = Date.distantFuture,
         selfPrivateKey: AgreementPrivateKey = AgreementPrivateKey(),
-        acknowledged: Bool = true) -> WCSession {
-            let peerKey = selfPrivateKey.publicKey.hexRepresentation
-            let selfKey = AgreementPrivateKey().publicKey.hexRepresentation
-            let controllerKey = isSelfController ? selfKey : peerKey
-            return WCSession(
-                topic: String.generateTopic(),
-                relay: RelayProtocolOptions.stub(),
-                controller: AgreementPeer(publicKey: controllerKey),
-                selfParticipant: Participant.stub(publicKey: selfKey),
-                peerParticipant: Participant.stub(publicKey: peerKey),
-                namespaces: [:],
-                events: [],
-                accounts: Account.stubSet(),
-                acknowledged: acknowledged,
-                expiry: Int64(expiryDate.timeIntervalSince1970))
-        }
+        namespaces: [String: SessionNamespace] = [:],
+        acknowledged: Bool = true
+    ) -> WCSession {
+        let peerKey = selfPrivateKey.publicKey.hexRepresentation
+        let selfKey = AgreementPrivateKey().publicKey.hexRepresentation
+        let controllerKey = isSelfController ? selfKey : peerKey
+        return WCSession(
+            topic: String.generateTopic(),
+            relay: RelayProtocolOptions.stub(),
+            controller: AgreementPeer(publicKey: controllerKey),
+            selfParticipant: Participant.stub(publicKey: selfKey),
+            peerParticipant: Participant.stub(publicKey: peerKey),
+            namespaces: namespaces,
+            events: [],
+            accounts: Account.stubSet(),
+            acknowledged: acknowledged,
+            expiry: Int64(expiryDate.timeIntervalSince1970))
+    }
 }
 
 extension Account {

--- a/Tests/WalletConnectSignTests/WCSessionTests.swift
+++ b/Tests/WalletConnectSignTests/WCSessionTests.swift
@@ -156,11 +156,60 @@ final class WCSessionTests: XCTestCase {
         XCTAssertNoThrow(try session.updateNamespaces(namespace))
     }
 
-    func testUpdateNamespaces() {
-        
+    func testUpdateNamespacesOverRequirement() {
+        let namespace = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount],
+                methods: ["method"],
+                events: ["event"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount],
+                        methods: ["method-2"],
+                        events: ["event-2"])])]
+        let newNamespace = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "newMethod"],
+                events: ["event", "newEvent"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount, polyAccount],
+                        methods: ["method-2", "newMethod-2"],
+                        events: ["event-2", "newEvent-2"])])]
+        var session = WCSession.stub(namespaces: namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(newNamespace))
     }
 
-    func testUpdateLessThanRequiredNamespaces() {
-        
+//    func testUpdateLessThanRequiredChains() {
+//        let namespace = [
+//            "eip155": SessionNamespace(
+//                accounts: [ethAccount],
+//                methods: ["method"],
+//                events: ["event"],
+//                extensions: [
+//                    SessionNamespace.Extension(
+//                        accounts: [ethAccount],
+//                        methods: ["method-2"],
+//                        events: ["event-2"])])]
+//        var session = WCSession.stub(namespaces: namespace)
+////        XCTAssertThrowsError()
+//    }
+    
+    func testUpdateLessThanRequiredAccounts() {
+        let required = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: nil)]
+        let invalid = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: nil)]
+        var session = WCSession.stub(namespaces: required)
+        XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
 }

--- a/Tests/WalletConnectSignTests/WCSessionTests.swift
+++ b/Tests/WalletConnectSignTests/WCSessionTests.swift
@@ -7,6 +7,8 @@ final class WCSessionTests: XCTestCase {
     let polyAccount = Account("eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb")!
     let cosmosAccount = Account("cosmos:cosmoshub-4:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0")!
 
+    // MARK: Namespace Permission Tests
+
     func testHasPermissionForMethod() {
         let namespace = [
             "eip155": SessionNamespace(
@@ -135,5 +137,31 @@ final class WCSessionTests: XCTestCase {
         var session = WCSession.stub()
         session.updateNamespaces(namespace)
         XCTAssertFalse(session.hasPermission(forEvent: "event", onChain: ethAccount.blockchain))
+    }
+
+    // MARK: Namespace Update Tests
+
+    func testUpdateEqualNamespaces() {
+        let namespace = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount],
+                methods: ["method"],
+                events: ["event"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount],
+                        methods: ["method-2"],
+                        events: ["event-2"])
+                ]
+            )
+        ]
+    }
+
+    func testUpdateNamespaces() {
+        
+    }
+
+    func testUpdateLessThanRequiredNamespaces() {
+        
     }
 }

--- a/Tests/WalletConnectSignTests/WCSessionTests.swift
+++ b/Tests/WalletConnectSignTests/WCSessionTests.swift
@@ -181,20 +181,20 @@ final class WCSessionTests: XCTestCase {
         XCTAssertNoThrow(try session.updateNamespaces(newNamespace))
     }
 
-//    func testUpdateLessThanRequiredChains() {
-//        let namespace = [
-//            "eip155": SessionNamespace(
-//                accounts: [ethAccount],
-//                methods: ["method"],
-//                events: ["event"],
-//                extensions: [
-//                    SessionNamespace.Extension(
-//                        accounts: [ethAccount],
-//                        methods: ["method-2"],
-//                        events: ["event-2"])])]
-//        var session = WCSession.stub(namespaces: namespace)
-////        XCTAssertThrowsError()
-//    }
+    func testUpdateLessThanRequiredChains() {
+        let namespace = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount],
+                methods: ["method"],
+                events: ["event"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount],
+                        methods: ["method-2"],
+                        events: ["event-2"])])]
+        var session = WCSession.stub(namespaces: namespace)
+        XCTAssertThrowsError(try session.updateNamespaces([:]))
+    }
     
     func testUpdateLessThanRequiredAccounts() {
         let required = [
@@ -209,6 +209,136 @@ final class WCSessionTests: XCTestCase {
                 methods: ["method", "method-2"],
                 events: ["event", "event-2"],
                 extensions: nil)]
+        var session = WCSession.stub(namespaces: required)
+        XCTAssertThrowsError(try session.updateNamespaces(invalid))
+    }
+    
+    func testUpdateLessThanRequiredMethods() {
+        let required = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: nil)]
+        let invalid = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method"],
+                events: ["event", "event-2"],
+                extensions: nil)]
+        var session = WCSession.stub(namespaces: required)
+        XCTAssertThrowsError(try session.updateNamespaces(invalid))
+    }
+    
+    func testUpdateLessThanRequiredEvents() {
+        let required = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: nil)]
+        let invalid = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event"],
+                extensions: nil)]
+        var session = WCSession.stub(namespaces: required)
+        XCTAssertThrowsError(try session.updateNamespaces(invalid))
+    }
+    
+    func testUpdateLessThanRequiredExtension() {
+        let required = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount, polyAccount],
+                        methods: ["method-2", "newMethod-2"],
+                        events: ["event-2", "newEvent-2"])])]
+        let invalid = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: nil)]
+        var session = WCSession.stub(namespaces: required)
+        XCTAssertThrowsError(try session.updateNamespaces(invalid))
+    }
+    
+    func testUpdateLessThanRequiredExtensionAccounts() {
+        let required = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount, polyAccount],
+                        methods: ["method-2", "newMethod-2"],
+                        events: ["event-2", "newEvent-2"])])]
+        let invalid = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount],
+                        methods: ["method-2", "newMethod-2"],
+                        events: ["event-2", "newEvent-2"])])]
+        var session = WCSession.stub(namespaces: required)
+        XCTAssertThrowsError(try session.updateNamespaces(invalid))
+    }
+    
+    func testUpdateLessThanRequiredExtensionMethods() {
+        let required = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount, polyAccount],
+                        methods: ["method-2", "newMethod-2"],
+                        events: ["event-2", "newEvent-2"])])]
+        let invalid = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount, polyAccount],
+                        methods: ["method-2"],
+                        events: ["event-2", "newEvent-2"])])]
+        var session = WCSession.stub(namespaces: required)
+        XCTAssertThrowsError(try session.updateNamespaces(invalid))
+    }
+    
+    func testUpdateLessThanRequiredExtensionEvents() {
+        let required = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount, polyAccount],
+                        methods: ["method-2", "newMethod-2"],
+                        events: ["event-2", "newEvent-2"])])]
+        let invalid = [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: [
+                    SessionNamespace.Extension(
+                        accounts: [ethAccount, polyAccount],
+                        methods: ["method-2", "newMethod-2"],
+                        events: ["event-2"])])]
         var session = WCSession.stub(namespaces: required)
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }

--- a/Tests/WalletConnectSignTests/WCSessionTests.swift
+++ b/Tests/WalletConnectSignTests/WCSessionTests.swift
@@ -18,7 +18,7 @@ final class WCSessionTests: XCTestCase {
                 extensions: nil)
         ]
         var session = WCSession.stub()
-        session.updateNamespaces(namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(namespace))
         XCTAssertTrue(session.hasPermission(forMethod: "method", onChain: ethAccount.blockchain))
     }
 
@@ -35,7 +35,7 @@ final class WCSessionTests: XCTestCase {
                         events: [])])
         ]
         var session = WCSession.stub()
-        session.updateNamespaces(namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(namespace))
         XCTAssertTrue(session.hasPermission(forMethod: "method", onChain: ethAccount.blockchain))
     }
 
@@ -53,7 +53,7 @@ final class WCSessionTests: XCTestCase {
                 extensions: nil)
         ]
         var session = WCSession.stub()
-        session.updateNamespaces(namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(namespace))
         XCTAssertFalse(session.hasPermission(forMethod: "method", onChain: ethAccount.blockchain))
     }
 
@@ -70,7 +70,7 @@ final class WCSessionTests: XCTestCase {
                         events: [])])
         ]
         var session = WCSession.stub()
-        session.updateNamespaces(namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(namespace))
         XCTAssertFalse(session.hasPermission(forMethod: "method", onChain: ethAccount.blockchain))
     }
 
@@ -83,7 +83,7 @@ final class WCSessionTests: XCTestCase {
                 extensions: nil)
         ]
         var session = WCSession.stub()
-        session.updateNamespaces(namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(namespace))
         XCTAssertTrue(session.hasPermission(forEvent: "event", onChain: ethAccount.blockchain))
     }
 
@@ -100,7 +100,7 @@ final class WCSessionTests: XCTestCase {
                         events: ["event"])])
         ]
         var session = WCSession.stub()
-        session.updateNamespaces(namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(namespace))
         XCTAssertTrue(session.hasPermission(forEvent: "event", onChain: ethAccount.blockchain))
     }
 
@@ -118,7 +118,7 @@ final class WCSessionTests: XCTestCase {
                 extensions: nil)
         ]
         var session = WCSession.stub()
-        session.updateNamespaces(namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(namespace))
         XCTAssertFalse(session.hasPermission(forEvent: "event", onChain: ethAccount.blockchain))
     }
 
@@ -135,7 +135,7 @@ final class WCSessionTests: XCTestCase {
                         events: ["event"])])
         ]
         var session = WCSession.stub()
-        session.updateNamespaces(namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(namespace))
         XCTAssertFalse(session.hasPermission(forEvent: "event", onChain: ethAccount.blockchain))
     }
 
@@ -151,10 +151,9 @@ final class WCSessionTests: XCTestCase {
                     SessionNamespace.Extension(
                         accounts: [ethAccount],
                         methods: ["method-2"],
-                        events: ["event-2"])
-                ]
-            )
-        ]
+                        events: ["event-2"])])]
+        var session = WCSession.stub(namespaces: namespace)
+        XCTAssertNoThrow(try session.updateNamespaces(namespace))
     }
 
     func testUpdateNamespaces() {

--- a/Tests/WalletConnectSignTests/WCSessionTests.swift
+++ b/Tests/WalletConnectSignTests/WCSessionTests.swift
@@ -140,18 +140,31 @@ final class WCSessionTests: XCTestCase {
     }
 
     // MARK: Namespace Update Tests
-
-    func testUpdateEqualNamespaces() {
-        let namespace = [
+    
+    private func stubRequiredNamespaces() -> [String: SessionNamespace] {
+        return [
             "eip155": SessionNamespace(
-                accounts: [ethAccount],
-                methods: ["method"],
-                events: ["event"],
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
+                extensions: nil)]
+    }
+    
+    private func stubRequiredNamespacesWithExtension() -> [String: SessionNamespace] {
+        return [
+            "eip155": SessionNamespace(
+                accounts: [ethAccount, polyAccount],
+                methods: ["method", "method-2"],
+                events: ["event", "event-2"],
                 extensions: [
                     SessionNamespace.Extension(
-                        accounts: [ethAccount],
-                        methods: ["method-2"],
-                        events: ["event-2"])])]
+                        accounts: [ethAccount, polyAccount],
+                        methods: ["method-2", "newMethod-2"],
+                        events: ["event-2", "newEvent-2"])])]
+    }
+
+    func testUpdateEqualNamespaces() {
+        let namespace = stubRequiredNamespaces()
         var session = WCSession.stub(namespaces: namespace)
         XCTAssertNoThrow(try session.updateNamespaces(namespace))
     }
@@ -182,103 +195,55 @@ final class WCSessionTests: XCTestCase {
     }
 
     func testUpdateLessThanRequiredChains() {
-        let namespace = [
-            "eip155": SessionNamespace(
-                accounts: [ethAccount],
-                methods: ["method"],
-                events: ["event"],
-                extensions: [
-                    SessionNamespace.Extension(
-                        accounts: [ethAccount],
-                        methods: ["method-2"],
-                        events: ["event-2"])])]
-        var session = WCSession.stub(namespaces: namespace)
+        var session = WCSession.stub(namespaces: stubRequiredNamespaces())
         XCTAssertThrowsError(try session.updateNamespaces([:]))
     }
     
     func testUpdateLessThanRequiredAccounts() {
-        let required = [
-            "eip155": SessionNamespace(
-                accounts: [ethAccount, polyAccount],
-                methods: ["method", "method-2"],
-                events: ["event", "event-2"],
-                extensions: nil)]
         let invalid = [
             "eip155": SessionNamespace(
                 accounts: [ethAccount],
                 methods: ["method", "method-2"],
                 events: ["event", "event-2"],
                 extensions: nil)]
-        var session = WCSession.stub(namespaces: required)
+        var session = WCSession.stub(namespaces: stubRequiredNamespaces())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
     
     func testUpdateLessThanRequiredMethods() {
-        let required = [
-            "eip155": SessionNamespace(
-                accounts: [ethAccount, polyAccount],
-                methods: ["method", "method-2"],
-                events: ["event", "event-2"],
-                extensions: nil)]
         let invalid = [
             "eip155": SessionNamespace(
                 accounts: [ethAccount, polyAccount],
                 methods: ["method"],
                 events: ["event", "event-2"],
                 extensions: nil)]
-        var session = WCSession.stub(namespaces: required)
+        var session = WCSession.stub(namespaces: stubRequiredNamespaces())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
     
     func testUpdateLessThanRequiredEvents() {
-        let required = [
-            "eip155": SessionNamespace(
-                accounts: [ethAccount, polyAccount],
-                methods: ["method", "method-2"],
-                events: ["event", "event-2"],
-                extensions: nil)]
         let invalid = [
             "eip155": SessionNamespace(
                 accounts: [ethAccount, polyAccount],
                 methods: ["method", "method-2"],
                 events: ["event"],
                 extensions: nil)]
-        var session = WCSession.stub(namespaces: required)
+        var session = WCSession.stub(namespaces: stubRequiredNamespaces())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
     
     func testUpdateLessThanRequiredExtension() {
-        let required = [
-            "eip155": SessionNamespace(
-                accounts: [ethAccount, polyAccount],
-                methods: ["method", "method-2"],
-                events: ["event", "event-2"],
-                extensions: [
-                    SessionNamespace.Extension(
-                        accounts: [ethAccount, polyAccount],
-                        methods: ["method-2", "newMethod-2"],
-                        events: ["event-2", "newEvent-2"])])]
         let invalid = [
             "eip155": SessionNamespace(
                 accounts: [ethAccount, polyAccount],
                 methods: ["method", "method-2"],
                 events: ["event", "event-2"],
                 extensions: nil)]
-        var session = WCSession.stub(namespaces: required)
+        var session = WCSession.stub(namespaces: stubRequiredNamespacesWithExtension())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
     
     func testUpdateLessThanRequiredExtensionAccounts() {
-        let required = [
-            "eip155": SessionNamespace(
-                accounts: [ethAccount, polyAccount],
-                methods: ["method", "method-2"],
-                events: ["event", "event-2"],
-                extensions: [
-                    SessionNamespace.Extension(
-                        accounts: [ethAccount, polyAccount],
-                        methods: ["method-2", "newMethod-2"],
-                        events: ["event-2", "newEvent-2"])])]
         let invalid = [
             "eip155": SessionNamespace(
                 accounts: [ethAccount, polyAccount],
@@ -289,21 +254,11 @@ final class WCSessionTests: XCTestCase {
                         accounts: [ethAccount],
                         methods: ["method-2", "newMethod-2"],
                         events: ["event-2", "newEvent-2"])])]
-        var session = WCSession.stub(namespaces: required)
+        var session = WCSession.stub(namespaces: stubRequiredNamespacesWithExtension())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
     
     func testUpdateLessThanRequiredExtensionMethods() {
-        let required = [
-            "eip155": SessionNamespace(
-                accounts: [ethAccount, polyAccount],
-                methods: ["method", "method-2"],
-                events: ["event", "event-2"],
-                extensions: [
-                    SessionNamespace.Extension(
-                        accounts: [ethAccount, polyAccount],
-                        methods: ["method-2", "newMethod-2"],
-                        events: ["event-2", "newEvent-2"])])]
         let invalid = [
             "eip155": SessionNamespace(
                 accounts: [ethAccount, polyAccount],
@@ -314,21 +269,11 @@ final class WCSessionTests: XCTestCase {
                         accounts: [ethAccount, polyAccount],
                         methods: ["method-2"],
                         events: ["event-2", "newEvent-2"])])]
-        var session = WCSession.stub(namespaces: required)
+        var session = WCSession.stub(namespaces: stubRequiredNamespacesWithExtension())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
     
     func testUpdateLessThanRequiredExtensionEvents() {
-        let required = [
-            "eip155": SessionNamespace(
-                accounts: [ethAccount, polyAccount],
-                methods: ["method", "method-2"],
-                events: ["event", "event-2"],
-                extensions: [
-                    SessionNamespace.Extension(
-                        accounts: [ethAccount, polyAccount],
-                        methods: ["method-2", "newMethod-2"],
-                        events: ["event-2", "newEvent-2"])])]
         let invalid = [
             "eip155": SessionNamespace(
                 accounts: [ethAccount, polyAccount],
@@ -339,7 +284,7 @@ final class WCSessionTests: XCTestCase {
                         accounts: [ethAccount, polyAccount],
                         methods: ["method-2", "newMethod-2"],
                         events: ["event-2"])])]
-        var session = WCSession.stub(namespaces: required)
+        var session = WCSession.stub(namespaces: stubRequiredNamespacesWithExtension())
         XCTAssertThrowsError(try session.updateNamespaces(invalid))
     }
 }


### PR DESCRIPTION
closes #252

**Changes**
- WCSession `updateNamespaces` now throws and checks the namespaces against the required namespaces.
- SessionNamespace `Extension` now has a superset check.
- Unit tests for `updateNamespaces` success and failure cases.