### PR TITLE
Feature: #290 HTTP client & auth challenge call

### DIFF
--- a/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
+++ b/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
@@ -15,10 +15,11 @@ final class RelayClientEndToEndTests: XCTestCase {
 
     func makeRelayClient() -> RelayClient {
         let logger = ConsoleLogger()
+        let client = HTTPClient(host: relayHost)
         let clientIdStorage = ClientIdStorage(keychain: KeychainStorageMock())
-        let socketAuthenticator = SocketAuthenticator(clientIdStorage: clientIdStorage)
-        let url = RelayClient.makeRelayUrl(host: relayHost, projectId: projectId, socketAuthenticator: socketAuthenticator)
-        let socket = WebSocket(url: url)
+        let authChallengeProvider = AuthChallengeProvider(client: client)
+        let socketAuthenticator = SocketAuthenticator(authChallengeProvider: authChallengeProvider, clientIdStorage: clientIdStorage)
+        let socket = AsyncWebSocketProxy(host: relayHost, projectId: projectId, socketFactory: SocketFactory(), socketAuthenticator: socketAuthenticator)
         let dispatcher = Dispatcher(socket: socket, socketConnectionHandler: ManualSocketConnectionHandler(socket: socket), logger: logger)
         return RelayClient(dispatcher: dispatcher, logger: logger, keyValueStorage: RuntimeKeyValueStorage())
     }

--- a/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
+++ b/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
@@ -13,19 +13,34 @@ final class RelayClientEndToEndTests: XCTestCase {
     let projectId = "8ba9ee138960775e5231b70cc5ef1c3a"
     private var publishers = [AnyCancellable]()
 
-    func makeRelayClient() -> RelayClient {
-        let logger = ConsoleLogger()
-        let client = HTTPClient(host: relayHost)
+    func makeSocket() -> WebSocketProxy {
         let clientIdStorage = ClientIdStorage(keychain: KeychainStorageMock())
+        let client = HTTPClient(host: relayHost)
         let authChallengeProvider = AuthChallengeProvider(client: client)
-        let socketAuthenticator = SocketAuthenticator(authChallengeProvider: authChallengeProvider, clientIdStorage: clientIdStorage)
-        let socket = AsyncWebSocketProxy(host: relayHost, projectId: projectId, socketFactory: SocketFactory(), socketAuthenticator: socketAuthenticator)
+        let socketAuthenticator = SocketAuthenticator(
+            authChallengeProvider: authChallengeProvider,
+            clientIdStorage: clientIdStorage
+        )
+        return AsyncWebSocketProxy(
+            host: relayHost,
+            projectId: projectId,
+            socketFactory: SocketFactory(),
+            socketAuthenticator: socketAuthenticator
+        )
+    }
+
+    func makeRelayClient(socket: WebSocketProxy) -> RelayClient {
+        let logger = ConsoleLogger()
         let dispatcher = Dispatcher(socket: socket, socketConnectionHandler: ManualSocketConnectionHandler(socket: socket), logger: logger)
         return RelayClient(dispatcher: dispatcher, logger: logger, keyValueStorage: RuntimeKeyValueStorage())
     }
 
     func testSubscribe() {
-        let relayClient = makeRelayClient()
+        let socket = makeSocket()
+        let relayClient = makeRelayClient(socket: socket)
+
+        waitSocketCreation(socket: socket)
+
         try! relayClient.connect()
         let subscribeExpectation = expectation(description: "subscribe call succeeds")
         subscribeExpectation.assertForOverFulfill = true
@@ -37,12 +52,19 @@ final class RelayClientEndToEndTests: XCTestCase {
                 }
             }
         }.store(in: &publishers)
-        waitForExpectations(timeout: defaultTimeout, handler: nil)
+
+        wait(for: [subscribeExpectation], timeout: defaultTimeout)
     }
 
     func testEndToEndPayload() {
-        let relayA = makeRelayClient()
-        let relayB = makeRelayClient()
+        let socketA = makeSocket()
+        let socketB = makeSocket()
+        let relayA = makeRelayClient(socket: socketA)
+        let relayB = makeRelayClient(socket: socketB)
+
+        waitSocketCreation(socket: socketA)
+        waitSocketCreation(socket: socketB)
+
         try! relayA.connect()
         try! relayB.connect()
 
@@ -85,13 +107,25 @@ final class RelayClientEndToEndTests: XCTestCase {
             }
         }.store(in: &publishers)
 
-        waitForExpectations(timeout: defaultTimeout, handler: nil)
+        wait(for: [expectationA, expectationB], timeout: defaultTimeout)
+
         XCTAssertEqual(subscriptionATopic, randomTopic)
         XCTAssertEqual(subscriptionBTopic, randomTopic)
 
         // TODO - uncomment lines when request rebound is resolved
 //        XCTAssertEqual(subscriptionBPayload, payloadA)
 //        XCTAssertEqual(subscriptionAPayload, payloadB)
+    }
+
+    private func waitSocketCreation(socket: WebSocketProxy) {
+        let createExpectation = expectation(description: "socket created")
+
+        socket.socketCreationPublisher.sink { _ in
+            createExpectation.fulfill()
+        }.store(in: &publishers)
+
+        wait(for: [createExpectation], timeout: defaultTimeout)
+
     }
 }
 

--- a/Sources/WalletConnectRelay/AsyncWebSocketProxy.swift
+++ b/Sources/WalletConnectRelay/AsyncWebSocketProxy.swift
@@ -50,20 +50,20 @@ final class AsyncWebSocketProxy: WebSocketProxy {
     }
 
     private func makeRelayUrl() async -> URL {
+        var components = URLComponents()
+        components.scheme = "wss"
+        components.host = host
+        components.queryItems = [
+            URLQueryItem(name: "projectId", value: projectId)
+        ]
         do {
             let authToken = try await socketAuthenticator.createAuthToken()
-
-            var components = URLComponents()
-            components.scheme = "wss"
-            components.host = host
-            components.queryItems = [
-                URLQueryItem(name: "projectId", value: projectId),
-                URLQueryItem(name: "auth", value: authToken)
-            ]
-            return components.url!
+            components.queryItems?.append(URLQueryItem(name: "auth", value: authToken))
         } catch {
-            fatalError("Auth token creation error: \(error.localizedDescription)")
+            // TODO: Handle token creation errors
+            print("Auth token creation error: \(error.localizedDescription)")
         }
+        return components.url!
     }
 }
 

--- a/Sources/WalletConnectRelay/AsyncWebSocketProxy.swift
+++ b/Sources/WalletConnectRelay/AsyncWebSocketProxy.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Combine
+
+protocol WebSocketProxy: WebSocketConnecting {
+    var socketCreationPublisher: AnyPublisher<WebSocketConnecting, Never> { get }
+}
+
+final class AsyncWebSocketProxy: WebSocketProxy {
+
+    private let socketCreationSubject = PassthroughSubject<WebSocketConnecting, Never>()
+
+    var socketCreationPublisher: AnyPublisher<WebSocketConnecting, Never> {
+        return socketCreationSubject.eraseToAnyPublisher()
+    }
+
+    var onConnect: (() -> Void)?
+    var onDisconnect: ((Error?) -> Void)?
+    var onText: ((String) -> Void)?
+
+    private var socket: WebSocketConnecting?
+
+    private let host: String
+    private let projectId: String
+    private let socketFactory: WebSocketFactory
+    private let socketAuthenticator: SocketAuthenticating
+
+    init(host: String, projectId: String, socketFactory: WebSocketFactory, socketAuthenticator: SocketAuthenticating) {
+        self.host = host
+        self.projectId = projectId
+        self.socketFactory = socketFactory
+        self.socketAuthenticator = socketAuthenticator
+
+        setUpSocket()
+    }
+
+    private func setUpSocket() {
+        Task(priority: .high) { [weak self] in
+            guard let self = self else { return }
+
+            let url = await makeRelayUrl()
+            let socket = socketFactory.create(with: url)
+
+            socket.onConnect = self.onConnect
+            socket.onDisconnect = self.onDisconnect
+            socket.onText = self.onText
+
+            self.socket = socket
+            self.socketCreationSubject.send(socket)
+        }
+    }
+
+    private func makeRelayUrl() async -> URL {
+        do {
+            let authToken = try await socketAuthenticator.createAuthToken()
+
+            var components = URLComponents()
+            components.scheme = "wss"
+            components.host = host
+            components.queryItems = [
+                URLQueryItem(name: "projectId", value: projectId),
+                URLQueryItem(name: "auth", value: authToken)
+            ]
+            return components.url!
+        } catch {
+            fatalError("Auth token creation error: \(error.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - WebSocketConnecting
+
+extension AsyncWebSocketProxy: WebSocketConnecting {
+    var isConnected: Bool {
+        return socket?.isConnected ?? false
+    }
+
+    func connect() {
+        socket?.connect()
+    }
+
+    func disconnect() {
+        socket?.disconnect()
+    }
+
+    func write(string: String, completion: (() -> Void)?) {
+        socket?.write(string: string, completion: completion)
+    }
+}

--- a/Sources/WalletConnectRelay/ClientAuth/AuthChallengeProvider.swift
+++ b/Sources/WalletConnectRelay/ClientAuth/AuthChallengeProvider.swift
@@ -19,7 +19,7 @@ actor AuthChallengeProvider: AuthChallengeProviding {
     func getChallenge(for clientId: String) async throws -> AuthChallenge {
         let endpoint = Endpoint(
             path: "/auth-nonce",
-            queryParameters: [URLQueryItem(name: "idd", value: clientId)])
+            queryParameters: [URLQueryItem(name: "did", value: clientId)])
         return try await client.request(AuthChallenge.self, at: endpoint)
     }
 }

--- a/Sources/WalletConnectRelay/ClientAuth/AuthChallengeProvider.swift
+++ b/Sources/WalletConnectRelay/ClientAuth/AuthChallengeProvider.swift
@@ -5,19 +5,21 @@ protocol AuthChallengeProviding {
 }
 
 actor AuthChallengeProvider: AuthChallengeProviding {
-    func getChallenge(for clientId: String) async throws -> String {
-        fatalError("not implemented")
-//        let endpoint = Endpoint(
-//            path: "/auth-nonce",
-//            queryParameters: [URLQueryItem(name: "idd", value: clientId)])
+
+    struct AuthNonce: Decodable {
+        let nonce: String
     }
-}
 
-struct Endpoint {
-    let path: String
-    let queryParameters: [URLQueryItem]
-}
+    var client: HTTPClient
 
-struct AuthNonce: Decodable {
-    let nonce: String
+    init(client: HTTPClient) {
+        self.client = client
+    }
+
+    func getChallenge(for clientId: String) async throws -> String {
+        let endpoint = Endpoint(
+            path: "/auth-nonce",
+            queryParameters: [URLQueryItem(name: "idd", value: clientId)])
+        return try await client.request(AuthNonce.self, at: endpoint).nonce
+    }
 }

--- a/Sources/WalletConnectRelay/ClientAuth/AuthChallengeProvider.swift
+++ b/Sources/WalletConnectRelay/ClientAuth/AuthChallengeProvider.swift
@@ -4,9 +4,20 @@ protocol AuthChallengeProviding {
     func getChallenge(for clientId: String) throws -> String
 }
 
-struct AuthChallengeProvider: AuthChallengeProviding {
-    func getChallenge(for clientId: String) throws -> String {
-        // TODO: Implement me
-        return "AuthChallenge"
+actor AuthChallengeProvider: AuthChallengeProviding {
+    func getChallenge(for clientId: String) async throws -> String {
+        fatalError("not implemented")
+//        let endpoint = Endpoint(
+//            path: "/auth-nonce",
+//            queryParameters: [URLQueryItem(name: "idd", value: clientId)])
     }
+}
+
+struct Endpoint {
+    let path: String
+    let queryParameters: [URLQueryItem]
+}
+
+struct AuthNonce: Decodable {
+    let nonce: String
 }

--- a/Sources/WalletConnectRelay/ClientAuth/AuthChallengeProvider.swift
+++ b/Sources/WalletConnectRelay/ClientAuth/AuthChallengeProvider.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 protocol AuthChallengeProviding {
-    func getChallenge(for clientId: String) throws -> String
+    func getChallenge(for clientId: String) async throws -> AuthChallenge
+}
+
+struct AuthChallenge: Decodable {
+    let nonce: String
 }
 
 actor AuthChallengeProvider: AuthChallengeProviding {
-
-    struct AuthNonce: Decodable {
-        let nonce: String
-    }
 
     var client: HTTPClient
 
@@ -16,10 +16,10 @@ actor AuthChallengeProvider: AuthChallengeProviding {
         self.client = client
     }
 
-    func getChallenge(for clientId: String) async throws -> String {
+    func getChallenge(for clientId: String) async throws -> AuthChallenge {
         let endpoint = Endpoint(
             path: "/auth-nonce",
             queryParameters: [URLQueryItem(name: "idd", value: clientId)])
-        return try await client.request(AuthNonce.self, at: endpoint).nonce
+        return try await client.request(AuthChallenge.self, at: endpoint)
     }
 }

--- a/Sources/WalletConnectRelay/ClientAuth/ClientIdStorage.swift
+++ b/Sources/WalletConnectRelay/ClientAuth/ClientIdStorage.swift
@@ -2,10 +2,10 @@ import Foundation
 import WalletConnectKMS
 
 protocol ClientIdStoring {
-    func getOrCreateKeyPair() throws -> SigningPrivateKey
+    func getOrCreateKeyPair() async throws -> SigningPrivateKey
 }
 
-struct ClientIdStorage: ClientIdStoring {
+actor ClientIdStorage: ClientIdStoring {
     private let key = "com.walletconnect.iridium.client_id"
     private let keychain: KeychainStorageProtocol
 
@@ -13,7 +13,7 @@ struct ClientIdStorage: ClientIdStoring {
         self.keychain = keychain
     }
 
-    func getOrCreateKeyPair() throws -> SigningPrivateKey {
+    func getOrCreateKeyPair() async throws -> SigningPrivateKey {
         do {
             return try keychain.read(key: key)
         } catch {

--- a/Sources/WalletConnectRelay/ClientAuth/DIDKeyFactory.swift
+++ b/Sources/WalletConnectRelay/ClientAuth/DIDKeyFactory.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol DIDKeyFactory {
-    func make(pubKey: Data) async -> String
+    func make(pubKey: Data, prefix: Bool) async -> String
 }
 
 /// A DID Method for Static Cryptographic Keys
@@ -13,11 +13,15 @@ actor ED25519DIDKeyFactory: DIDKeyFactory {
     private let MULTICODEC_ED25519_HEADER: [UInt8] = [0xed, 0x01]
     private let MULTICODEC_ED25519_BASE = "z"
 
-    func make(pubKey: Data) async -> String {
+    func make(pubKey: Data, prefix: Bool) async -> String {
+        let multibase = multibase(pubKey: pubKey)
+
+        guard prefix else { return multibase }
+
         return [
             DID_PREFIX,
             DID_METHOD,
-            multibase(pubKey: pubKey)
+            multibase
         ].joined(separator: DID_DELIMITER)
     }
 

--- a/Sources/WalletConnectRelay/ClientAuth/DIDKeyFactory.swift
+++ b/Sources/WalletConnectRelay/ClientAuth/DIDKeyFactory.swift
@@ -1,19 +1,19 @@
 import Foundation
 
 protocol DIDKeyFactory {
-    func make(pubKey: Data) -> String
+    func make(pubKey: Data) async -> String
 }
 
 /// A DID Method for Static Cryptographic Keys
 /// did-key-format := did:key:MULTIBASE(base58-btc, MULTICODEC(public-key-type, raw-public-key-bytes))
-struct ED25519DIDKeyFactory: DIDKeyFactory {
+actor ED25519DIDKeyFactory: DIDKeyFactory {
     private let DID_DELIMITER = ":"
     private let DID_PREFIX = "did"
     private let DID_METHOD = "key"
     private let MULTICODEC_ED25519_HEADER: [UInt8] = [0xed, 0x01]
     private let MULTICODEC_ED25519_BASE = "z"
 
-    func make(pubKey: Data) -> String {
+    func make(pubKey: Data) async -> String {
         return [
             DID_PREFIX,
             DID_METHOD,

--- a/Sources/WalletConnectRelay/ClientAuth/SocketAuthenticator.swift
+++ b/Sources/WalletConnectRelay/ClientAuth/SocketAuthenticator.swift
@@ -10,7 +10,7 @@ struct SocketAuthenticator: SocketAuthenticating {
     private let clientIdStorage: ClientIdStoring
     private let didKeyFactory: DIDKeyFactory
 
-    init(authChallengeProvider: AuthChallengeProviding = AuthChallengeProvider(),
+    init(authChallengeProvider: AuthChallengeProviding,
          clientIdStorage: ClientIdStoring,
          didKeyFactory: DIDKeyFactory = ED25519DIDKeyFactory()) {
         self.authChallengeProvider = authChallengeProvider
@@ -18,10 +18,10 @@ struct SocketAuthenticator: SocketAuthenticating {
         self.didKeyFactory = didKeyFactory
     }
 
-    func createAuthToken() throws -> String {
-        let clientIdKeyPair = try clientIdStorage.getOrCreateKeyPair()
-        let challenge = try authChallengeProvider.getChallenge(for: clientIdKeyPair.publicKey.hexRepresentation)
-        return try signJWT(subject: challenge, keyPair: clientIdKeyPair)
+    func createAuthToken() async throws -> String {
+        let clientIdKeyPair = try await clientIdStorage.getOrCreateKeyPair()
+        let challenge = try await authChallengeProvider.getChallenge(for: clientIdKeyPair.publicKey.hexRepresentation)
+        return try signJWT(subject: challenge.nonce, keyPair: clientIdKeyPair)
     }
 
     private func signJWT(subject: String, keyPair: SigningPrivateKey) throws -> String {

--- a/Sources/WalletConnectRelay/HTTP/HTTPClient.swift
+++ b/Sources/WalletConnectRelay/HTTP/HTTPClient.swift
@@ -1,14 +1,35 @@
 import Foundation
 
-actor HTTPClient {
+final class HTTPClient {
 
-    private let session: URLSession = .shared
+    let host: String
 
-    func request(_ url: URL) {
-        let request = URLRequest(url: url)
+    private let session: URLSession
+
+    init(host: String, session: URLSession = .shared) {
+        self.host = host
+        self.session = session
+    }
+
+    func request<T: Decodable>(_ endpoint: Endpoint, completion: @escaping (HTTPResponse<T>) -> Void) {
+        let request = makeRequest(for: endpoint)
         session.dataTask(with: request) { data, response, error in
-//            HTTPResponse(request: request, data: data, response: response, error: error)
+            completion(HTTPResponse(request: request, data: data, response: response, error: error))
         }.resume()
+    }
+
+    func makeRequest(for endpoint: Endpoint) -> URLRequest {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = endpoint.path
+        components.queryItems = []
+        guard let url = components.url else {
+            fatalError()
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        return request
     }
 }
 

--- a/Sources/WalletConnectRelay/HTTP/HTTPClient.swift
+++ b/Sources/WalletConnectRelay/HTTP/HTTPClient.swift
@@ -5,7 +5,7 @@ struct Endpoint {
     let queryParameters: [URLQueryItem]
 }
 
-final class HTTPClient {
+actor HTTPClient {
 
     let host: String
 
@@ -41,9 +41,9 @@ final class HTTPClient {
         components.scheme = "https"
         components.host = host
         components.path = endpoint.path
-        components.queryItems = []
+        components.queryItems = endpoint.queryParameters
         guard let url = components.url else {
-            fatalError()
+            fatalError() // TODO: Remove fatal error when url fails to build
         }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"

--- a/Sources/WalletConnectRelay/HTTP/HTTPClient.swift
+++ b/Sources/WalletConnectRelay/HTTP/HTTPClient.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+actor HTTPClient {
+
+    private let session: URLSession = .shared
+
+    func request(_ url: URL) {
+        let request = URLRequest(url: url)
+        session.dataTask(with: request) { data, response, error in
+//            HTTPResponse(request: request, data: data, response: response, error: error)
+        }.resume()
+    }
+}
+
+enum HTTPError: Error {
+    case dataTaskError(Error)
+    case noResponse
+    case badStatusCode(Int)
+    case responseDataNil
+    case jsonDecodeFailed(Error, Data)
+}
+
+struct HTTPResponse<T: Decodable> {
+
+    let request: URLRequest?
+    let data: Data?
+    let urlResponse: HTTPURLResponse?
+    let result: Result<T, Error>
+
+    init(request: URLRequest? = nil, data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) {
+        self.data = data
+        self.request = request
+        self.urlResponse = response as? HTTPURLResponse
+        self.result = Self.validate(data, response, error).flatMap { data -> Result<T, Error> in
+            if let rawData = data as? T {
+                return .success(rawData)
+            }
+            return Self.decode(data)
+        }
+    }
+}
+
+extension HTTPResponse {
+
+    private static func validate(_ data: Data?, _ urlResponse: URLResponse?, _ error: Error?) -> Result<Data, Error> {
+        if let error = error {
+            return .failure(HTTPError.dataTaskError(error))
+        }
+        guard let httpResponse = urlResponse as? HTTPURLResponse else {
+            return .failure(HTTPError.noResponse)
+        }
+        guard (200..<300) ~= httpResponse.statusCode else {
+            return .failure(HTTPError.badStatusCode(httpResponse.statusCode))
+        }
+        guard let validData = data else {
+            return .failure(HTTPError.responseDataNil)
+        }
+        return .success(validData)
+    }
+
+    private static func decode<T: Decodable>(_ data: Data) -> Result<T, Error> {
+        do {
+            let decoded = try JSONDecoder().decode(T.self, from: data)
+            return .success(decoded)
+        } catch let jsonError {
+            return .failure(HTTPError.jsonDecodeFailed(jsonError, data))
+        }
+    }
+}

--- a/Sources/WalletConnectRelay/HTTP/HTTPError.swift
+++ b/Sources/WalletConnectRelay/HTTP/HTTPError.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum HTTPError: Error {
+    case dataTaskError(Error)
+    case noResponse
+    case badStatusCode(Int)
+    case responseDataNil
+    case jsonDecodeFailed(Error, Data)
+}

--- a/Sources/WalletConnectRelay/HTTP/HTTPResponse.swift
+++ b/Sources/WalletConnectRelay/HTTP/HTTPResponse.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct HTTPResponse<T: Decodable> {
+
+    let request: URLRequest?
+    let data: Data?
+    let urlResponse: HTTPURLResponse?
+    let result: Result<T, Error>
+
+    init(request: URLRequest? = nil, data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) {
+        self.data = data
+        self.request = request
+        self.urlResponse = response as? HTTPURLResponse
+        self.result = Self.validate(data, response, error).flatMap { data -> Result<T, Error> in
+            if let rawData = data as? T {
+                return .success(rawData)
+            }
+            return Self.decode(data)
+        }
+    }
+}
+
+extension HTTPResponse {
+
+    private static func validate(_ data: Data?, _ urlResponse: URLResponse?, _ error: Error?) -> Result<Data, Error> {
+        if let error = error {
+            return .failure(HTTPError.dataTaskError(error))
+        }
+        guard let httpResponse = urlResponse as? HTTPURLResponse else {
+            return .failure(HTTPError.noResponse)
+        }
+        guard (200..<300) ~= httpResponse.statusCode else {
+            return .failure(HTTPError.badStatusCode(httpResponse.statusCode))
+        }
+        guard let validData = data else {
+            return .failure(HTTPError.responseDataNil)
+        }
+        return .success(validData)
+    }
+
+    private static func decode<T: Decodable>(_ data: Data) -> Result<T, Error> {
+        do {
+            let decoded = try JSONDecoder().decode(T.self, from: data)
+            return .success(decoded)
+        } catch let jsonError {
+            return .failure(HTTPError.jsonDecodeFailed(jsonError, data))
+        }
+    }
+}

--- a/Sources/WalletConnectRelay/RelayClient.swift
+++ b/Sources/WalletConnectRelay/RelayClient.swift
@@ -66,8 +66,9 @@ public final class RelayClient {
         socketConnectionType: SocketConnectionType = .automatic,
         logger: ConsoleLogging = ConsoleLogger(loggingLevel: .off)
     ) {
+        let client = HTTPClient(host: relayHost)
         let socketAuthenticator = SocketAuthenticator(
-            authChallengeProvider: AuthChallengeProvider(),
+            authChallengeProvider: AuthChallengeProvider(client: client),
             clientIdStorage: ClientIdStorage(keychain: keychainStorage),
             didKeyFactory: ED25519DIDKeyFactory()
         )
@@ -252,7 +253,7 @@ public final class RelayClient {
     }
 
     internal static func makeRelayUrl(host: String, projectId: String, socketAuthenticator: SocketAuthenticating) -> URL {
-        guard let authToken = try? socketAuthenticator.createAuthToken()
+        guard let authToken = try? socketAuthenticator.createAuthToken() 
         else { fatalError("Auth token creation error") }
 
         var components = URLComponents()

--- a/Sources/WalletConnectRelay/RelayClient.swift
+++ b/Sources/WalletConnectRelay/RelayClient.swift
@@ -72,11 +72,12 @@ public final class RelayClient {
             clientIdStorage: ClientIdStorage(keychain: keychainStorage),
             didKeyFactory: ED25519DIDKeyFactory()
         )
-        let socket = socketFactory.create(with: Self.makeRelayUrl(
+        let socket = AsyncWebSocketProxy(
             host: relayHost,
             projectId: projectId,
+            socketFactory: socketFactory,
             socketAuthenticator: socketAuthenticator
-        ))
+        )
         let socketConnectionHandler: SocketConnectionHandler
         switch socketConnectionType {
         case .automatic:
@@ -250,19 +251,5 @@ public final class RelayClient {
                 self?.logger.debug("Failed to Respond for request id: \(requestId), error: \(error)")
             }
         }
-    }
-
-    internal static func makeRelayUrl(host: String, projectId: String, socketAuthenticator: SocketAuthenticating) -> URL {
-        guard let authToken = try? socketAuthenticator.createAuthToken() 
-        else { fatalError("Auth token creation error") }
-
-        var components = URLComponents()
-        components.scheme = "wss"
-        components.host = host
-        components.queryItems = [
-            URLQueryItem(name: "projectId", value: projectId),
-            URLQueryItem(name: "auth", value: authToken)
-        ]
-        return components.url!
     }
 }

--- a/Sources/WalletConnectRelay/SocketConnectionHandler/SocketConnectionHandler.swift
+++ b/Sources/WalletConnectRelay/SocketConnectionHandler/SocketConnectionHandler.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 protocol SocketConnectionHandler {
-    var socket: WebSocketConnecting { get }
     func handleConnect() throws
     func handleDisconnect(closeCode: URLSessionWebSocketTask.CloseCode) throws
 }

--- a/Sources/WalletConnectRelay/SocketConnectionHandler/WebSocket.swift
+++ b/Sources/WalletConnectRelay/SocketConnectionHandler/WebSocket.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol WebSocketConnecting {
+public protocol WebSocketConnecting: AnyObject {
     var isConnected: Bool { get }
     var onConnect: (() -> Void)? { get set }
     var onDisconnect: ((Error?) -> Void)? { get set }

--- a/Tests/IntegrationTests/AuthChallengeTests.swift
+++ b/Tests/IntegrationTests/AuthChallengeTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+import WalletConnectKMS
+@testable import WalletConnectRelay
+
+final class AuthChallengeTests: XCTestCase {
+
+    let relayHost: String = "dev.relay.walletconnect.com"
+
+    var httpClient: HTTPClient!
+    var provider: AuthChallengeProvider!
+
+    override func setUp() {
+        httpClient = HTTPClient(host: relayHost)
+        provider = AuthChallengeProvider(client: httpClient)
+    }
+
+    func testGetChallenge() async throws {
+        let key = SigningPrivateKey().publicKey.hexRepresentation
+        let challenge = try await provider.getChallenge(for: key)
+        XCTAssertFalse(challenge.nonce.isEmpty)
+    }
+}

--- a/Tests/RelayerTests/AuthTests/ClientIdStorageTests.swift
+++ b/Tests/RelayerTests/AuthTests/ClientIdStorageTests.swift
@@ -6,16 +6,16 @@ import WalletConnectKMS
 
 final class ClientIdStorageTests: XCTestCase {
 
-    func testGetOrCreate() throws {
+    func testGetOrCreate() async throws {
         let keychain = KeychainStorageMock()
         let storage = ClientIdStorage(keychain: keychain)
 
         XCTAssertThrowsError(try keychain.read(key: "com.walletconnect.iridium.client_id") as SigningPrivateKey)
 
-        let saved = try storage.getOrCreateKeyPair()
+        let saved = try await storage.getOrCreateKeyPair()
         XCTAssertEqual(saved, try keychain.read(key: "com.walletconnect.iridium.client_id"))
 
-        let restored = try storage.getOrCreateKeyPair()
+        let restored = try await storage.getOrCreateKeyPair()
         XCTAssertEqual(saved, restored)
     }
 }

--- a/Tests/RelayerTests/AuthTests/ED25519DIDKeyTests.swift
+++ b/Tests/RelayerTests/AuthTests/ED25519DIDKeyTests.swift
@@ -3,7 +3,8 @@ import XCTest
 @testable import WalletConnectRelay
 
 final class ED25519DIDKeyFactoryTests: XCTestCase {
-    let expectedDid = "did:key:z6MkodHZwneVRShtaLf8JKYkxpDGp1vGZnpGmdBpX8M2exxH"
+    let expectedDidWithPrefix = "did:key:z6MkodHZwneVRShtaLf8JKYkxpDGp1vGZnpGmdBpX8M2exxH"
+    let expectedDidWithoutPrefix = "z6MkodHZwneVRShtaLf8JKYkxpDGp1vGZnpGmdBpX8M2exxH"
     let pubKey = Data(hex: "884ab67f787b69e534bfdba8d5beb4e719700e90ac06317ed177d49e5a33be5a")
 
     var sut: ED25519DIDKeyFactory!
@@ -12,8 +13,13 @@ final class ED25519DIDKeyFactoryTests: XCTestCase {
         sut = ED25519DIDKeyFactory()
     }
 
-    func testKeyCreation() async {
-        let did = await sut.make(pubKey: pubKey)
-        XCTAssertEqual(expectedDid, did)
+    func testKeyCreationWithoutPrefix() async {
+        let did = await sut.make(pubKey: pubKey, prefix: false)
+        XCTAssertEqual(expectedDidWithoutPrefix, did)
+    }
+
+    func testKeyCreationWithPrefix() async {
+        let did = await sut.make(pubKey: pubKey, prefix: true)
+        XCTAssertEqual(expectedDidWithPrefix, did)
     }
 }

--- a/Tests/RelayerTests/AuthTests/ED25519DIDKeyTests.swift
+++ b/Tests/RelayerTests/AuthTests/ED25519DIDKeyTests.swift
@@ -12,8 +12,8 @@ final class ED25519DIDKeyFactoryTests: XCTestCase {
         sut = ED25519DIDKeyFactory()
     }
 
-    func testKeyCreation() {
-        let did = sut.make(pubKey: pubKey)
+    func testKeyCreation() async {
+        let did = await sut.make(pubKey: pubKey)
         XCTAssertEqual(expectedDid, did)
     }
 }

--- a/Tests/RelayerTests/AuthTests/SocketAuthenticatorTests.swift
+++ b/Tests/RelayerTests/AuthTests/SocketAuthenticatorTests.swift
@@ -21,12 +21,12 @@ final class SocketAuthenticatorTests: XCTestCase {
         didKeyFactory: DIDKeyFactory)
     }
 
-    func test() async {
+    func test() async throws {
         authChallengeProvider.challenge = AuthChallenge(nonce: "c479fe5dc464e771e78b193d239a65b58d278cad1c34bfb0b5716e5bb514928e")
         let keyRaw = Data(hex: "58e0254c211b858ef7896b00e3f36beeb13d568d47c6031c4218b87718061295")
-        let signingKey = try! SigningPrivateKey(rawRepresentation: keyRaw)
+        let signingKey = try SigningPrivateKey(rawRepresentation: keyRaw)
         clientIdStorage.keyPair = signingKey
-        let token = try! sut.createAuthToken()
+        let token = try await sut.createAuthToken()
         XCTAssertNotNil(token)
     }
 }

--- a/Tests/RelayerTests/AuthTests/SocketAuthenticatorTests.swift
+++ b/Tests/RelayerTests/AuthTests/SocketAuthenticatorTests.swift
@@ -21,8 +21,8 @@ final class SocketAuthenticatorTests: XCTestCase {
         didKeyFactory: DIDKeyFactory)
     }
 
-    func test() {
-        authChallengeProvider.challange = "c479fe5dc464e771e78b193d239a65b58d278cad1c34bfb0b5716e5bb514928e"
+    func test() async {
+        authChallengeProvider.challenge = AuthChallenge(nonce: "c479fe5dc464e771e78b193d239a65b58d278cad1c34bfb0b5716e5bb514928e")
         let keyRaw = Data(hex: "58e0254c211b858ef7896b00e3f36beeb13d568d47c6031c4218b87718061295")
         let signingKey = try! SigningPrivateKey(rawRepresentation: keyRaw)
         clientIdStorage.keyPair = signingKey

--- a/Tests/RelayerTests/AutomaticSocketConnectionHandlerTests.swift
+++ b/Tests/RelayerTests/AutomaticSocketConnectionHandlerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class AutomaticSocketConnectionHandlerTests: XCTestCase {
     var sut: AutomaticSocketConnectionHandler!
-    var webSocketSession: WebSocketConnecting!
+    var webSocketSession: WebSocketMock!
     var networkMonitor: NetworkMonitoringMock!
     var appStateObserver: AppStateObserving!
     var backgroundTaskRegistrar: BackgroundTaskRegistrarMock!
@@ -48,6 +48,7 @@ final class AutomaticSocketConnectionHandlerTests: XCTestCase {
     }
 
     func testDisconnectOnEndBackgroundTask() {
+        webSocketSession.socketCreationSubject.send(webSocketSession)
         appStateObserver.onWillEnterBackground?()
         XCTAssertTrue(sut.socket.isConnected)
         backgroundTaskRegistrar.completion!()

--- a/Tests/RelayerTests/DispatcherTests.swift
+++ b/Tests/RelayerTests/DispatcherTests.swift
@@ -2,8 +2,16 @@ import Foundation
 import XCTest
 @testable import WalletConnectRelay
 import TestingUtils
+import Combine
 
-class WebSocketMock: WebSocketConnecting {
+class WebSocketMock: WebSocketProxy {
+
+    let socketCreationSubject = PassthroughSubject<WebSocketConnecting, Never>()
+
+    var socketCreationPublisher: AnyPublisher<WebSocketConnecting, Never> {
+        return socketCreationSubject.eraseToAnyPublisher()
+    }
+
     var onText: ((String) -> Void)?
     var onConnect: (() -> Void)?
     var onDisconnect: ((Error?) -> Void)?

--- a/Tests/RelayerTests/HTTPResponseTests.swift
+++ b/Tests/RelayerTests/HTTPResponseTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import TestingUtils
+@testable import WalletConnectRelay
+
+final class HTTPResponseTests: XCTestCase {
+
+    static let url = URL(string: "https://httpbin.org/")!
+    let request = URLRequest(url: url)
+    let validData = try! JSONEncoder().encode("data")
+    
+    let successResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)
+    let failureResponse = HTTPURLResponse(url: url, statusCode: 400, httpVersion: "HTTP/1.1", headerFields: nil)
+
+    // MARK: Success cases
+
+    func testInitGetDecodableData() {
+        let response: HTTPResponse<String> = HTTPResponse(request: request, data: validData, response: successResponse, error: nil)
+        XCTAssertNoThrow(try response.result.get())
+    }
+
+    func testInitGetRawData() {
+        let response: HTTPResponse<Data> = HTTPResponse(request: request, data: validData, response: successResponse, error: nil)
+        XCTAssertNoThrow(try response.result.get())
+    }
+
+    // MARK: Failure cases
+
+    func testInitWithError() {
+        let response: HTTPResponse<String> = HTTPResponse(request: request, error: AnyError())
+        XCTAssertNotNil(response.request)
+        XCTAssertThrowsError(try response.result.get())
+    }
+
+    func testInitWithNoResponse() {
+        let response: HTTPResponse<String> = HTTPResponse(request: request, data: validData, response: nil, error: nil)
+        XCTAssertNil(response.urlResponse)
+        XCTAssertThrowsError(try response.result.get()) { error in
+            XCTAssert((error as? HTTPError)?.isNoResponseError == true)
+        }
+    }
+
+    func testInitWithBadResponse() {
+        let response: HTTPResponse<String> = HTTPResponse(request: request, data: validData, response: failureResponse, error: nil)
+        XCTAssertThrowsError(try response.result.get()) { error in
+            XCTAssert((error as? HTTPError)?.isBadStatusCodeError == true)
+        }
+    }
+
+    func testInitWithNoData() {
+        let response: HTTPResponse<String> = HTTPResponse(request: request, data: nil, response: successResponse, error: nil)
+        XCTAssertThrowsError(try response.result.get()) { error in
+            XCTAssert((error as? HTTPError)?.isNilDataError == true)
+        }
+    }
+
+    func testInitWithInvalidData() {
+        let response: HTTPResponse<Int> = HTTPResponse(request: request, data: validData, response: successResponse, error: nil)
+        XCTAssertThrowsError(try response.result.get()) { error in
+            XCTAssert((error as? HTTPError)?.isDecodeError == true)
+        }
+    }
+}

--- a/Tests/RelayerTests/HTTPResponseTests.swift
+++ b/Tests/RelayerTests/HTTPResponseTests.swift
@@ -7,7 +7,7 @@ final class HTTPResponseTests: XCTestCase {
     static let url = URL(string: "https://httpbin.org/")!
     let request = URLRequest(url: url)
     let validData = try! JSONEncoder().encode("data")
-    
+
     let successResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)
     let failureResponse = HTTPURLResponse(url: url, statusCode: 400, httpVersion: "HTTP/1.1", headerFields: nil)
 

--- a/Tests/RelayerTests/HTTPResponseTests.swift
+++ b/Tests/RelayerTests/HTTPResponseTests.swift
@@ -35,28 +35,28 @@ final class HTTPResponseTests: XCTestCase {
         let response: HTTPResponse<String> = HTTPResponse(request: request, data: validData, response: nil, error: nil)
         XCTAssertNil(response.urlResponse)
         XCTAssertThrowsError(try response.result.get()) { error in
-            XCTAssert((error as? HTTPError)?.isNoResponseError == true)
+            XCTAssert(error.asHttpError?.isNoResponseError == true)
         }
     }
 
     func testInitWithBadResponse() {
         let response: HTTPResponse<String> = HTTPResponse(request: request, data: validData, response: failureResponse, error: nil)
         XCTAssertThrowsError(try response.result.get()) { error in
-            XCTAssert((error as? HTTPError)?.isBadStatusCodeError == true)
+            XCTAssert(error.asHttpError?.isBadStatusCodeError == true)
         }
     }
 
     func testInitWithNoData() {
         let response: HTTPResponse<String> = HTTPResponse(request: request, data: nil, response: successResponse, error: nil)
         XCTAssertThrowsError(try response.result.get()) { error in
-            XCTAssert((error as? HTTPError)?.isNilDataError == true)
+            XCTAssert(error.asHttpError?.isNilDataError == true)
         }
     }
 
     func testInitWithInvalidData() {
         let response: HTTPResponse<Int> = HTTPResponse(request: request, data: validData, response: successResponse, error: nil)
         XCTAssertThrowsError(try response.result.get()) { error in
-            XCTAssert((error as? HTTPError)?.isDecodeError == true)
+            XCTAssert(error.asHttpError?.isDecodeError == true)
         }
     }
 }

--- a/Tests/RelayerTests/Helpers/Error+Extension.swift
+++ b/Tests/RelayerTests/Helpers/Error+Extension.swift
@@ -33,4 +33,27 @@ extension NetworkError {
     }
 }
 
+extension HTTPError {
+
+    var isNoResponseError: Bool {
+        if case .noResponse = self { return true }
+        return false
+    }
+
+    var isBadStatusCodeError: Bool {
+        if case .badStatusCode = self { return true }
+        return false
+    }
+
+    var isNilDataError: Bool {
+        if case .responseDataNil = self { return true }
+        return false
+    }
+
+    var isDecodeError: Bool {
+        if case .jsonDecodeFailed = self { return true }
+        return false
+    }
+}
+
 extension String: Error {}

--- a/Tests/RelayerTests/Helpers/Error+Extension.swift
+++ b/Tests/RelayerTests/Helpers/Error+Extension.swift
@@ -13,6 +13,10 @@ extension Error {
     var asNetworkError: NetworkError? {
         return self as? NetworkError
     }
+
+    var asHttpError: HTTPError? {
+        return self as? HTTPError
+    }
 }
 
 extension NetworkError {

--- a/Tests/RelayerTests/Mocks/AuthChallengeProviderMock.swift
+++ b/Tests/RelayerTests/Mocks/AuthChallengeProviderMock.swift
@@ -3,9 +3,9 @@ import Foundation
 import Foundation
 
 class AuthChallengeProviderMock: AuthChallengeProviding {
-    var challange: String!
+    var challenge: AuthChallenge!
 
-    func getChallenge(for clientId: String) throws -> String {
-        return challange
+    func getChallenge(for clientId: String) async throws -> AuthChallenge {
+        return challenge
     }
 }

--- a/Tests/RelayerTests/Mocks/ED25519DIDKeyFactoryMock.swift
+++ b/Tests/RelayerTests/Mocks/ED25519DIDKeyFactoryMock.swift
@@ -4,7 +4,7 @@ import Foundation
 
 struct ED25519DIDKeyFactoryMock: DIDKeyFactory {
     var did: String!
-    func make(pubKey: Data) -> String {
+    func make(pubKey: Data, prefix: Bool) -> String {
         return did
     }
 }

--- a/Tests/TestingUtils/HelperTypes.swift
+++ b/Tests/TestingUtils/HelperTypes.swift
@@ -1,4 +1,6 @@
-public struct AnyError: Error {}
+public struct AnyError: Error {
+    public init() {}
+}
 
 public struct EmptyCodable: Codable {
     public init() {}


### PR DESCRIPTION
closes #290 

### What's changed:
- HTTP client added to relay package w/ completion & async methods. Session's standard `async` API requires iOS 15+
- Integrated `AuthChallengeProvider` call. Integration tested on dev API.

PS: It's ready, only needs to be instantiated in the SDK