### PR TITLE
[Network] Feature: #330 Granular tags

### DIFF
--- a/Sources/Chat/NetworkingInteractor.swift
+++ b/Sources/Chat/NetworkingInteractor.swift
@@ -10,7 +10,7 @@ protocol NetworkInteracting {
     var responsePublisher: AnyPublisher<ChatResponse, Never> {get}
     func subscribe(topic: String) async throws
     func request(_ request: JSONRPCRequest<ChatRequestParams>, topic: String, envelopeType: Envelope.EnvelopeType) async throws
-    func respond(topic: String, response: JsonRpcResult) async throws
+    func respond(topic: String, response: JsonRpcResult, tag: Int) async throws
 }
 
 extension NetworkInteracting {
@@ -56,12 +56,12 @@ class NetworkingInteractor: NetworkInteracting {
     func request(_ request: JSONRPCRequest<ChatRequestParams>, topic: String, envelopeType: Envelope.EnvelopeType) async throws {
         try jsonRpcHistory.set(topic: topic, request: request)
         let message = try! serializer.serialize(topic: topic, encodable: request, envelopeType: envelopeType)
-        try await relayClient.publish(topic: topic, payload: message, tag: .chat)
+        try await relayClient.publish(topic: topic, payload: message, tag: request.params.tag)
     }
 
-    func respond(topic: String, response: JsonRpcResult) async throws {
+    func respond(topic: String, response: JsonRpcResult, tag: Int) async throws {
         let message = try serializer.serialize(topic: topic, encodable: response.value)
-        try await relayClient.publish(topic: topic, payload: message, tag: .chat, prompt: false)
+        try await relayClient.publish(topic: topic, payload: message, tag: tag, prompt: false)
     }
 
     func subscribe(topic: String) async throws {

--- a/Sources/Chat/ProtocolServices/Invitee/InvitationHandlingService.swift
+++ b/Sources/Chat/ProtocolServices/Invitee/InvitationHandlingService.swift
@@ -50,7 +50,7 @@ class InvitationHandlingService {
 
         let responseTopic = try getInviteResponseTopic(payload, invite)
 
-        try await networkingInteractor.respond(topic: responseTopic, response: response)
+        try await networkingInteractor.respond(topic: responseTopic, response: response, tag: payload.request.params.responseTag)
 
         let threadAgreementKeys = try kms.performKeyAgreement(selfPublicKey: selfThreadPubKey, peerPublicKey: invite.publicKey)
 
@@ -84,7 +84,7 @@ class InvitationHandlingService {
         let error = JSONRPCErrorResponse.Error(code: 0, message: "user rejected")
         let response = JsonRpcResult.error(JSONRPCErrorResponse(id: payload.request.id, error: error))
 
-        try await networkingInteractor.respond(topic: responseTopic, response: response)
+        try await networkingInteractor.respond(topic: responseTopic, response: response, tag: payload.request.params.responseTag)
 
         invitePayloadStore.delete(forKey: inviteId)
     }

--- a/Sources/Chat/Types/ChatRequestParams.swift
+++ b/Sources/Chat/Types/ChatRequestParams.swift
@@ -33,6 +33,22 @@ enum ChatRequestParams: Codable, Equatable {
     }
 }
 
+extension ChatRequestParams {
+
+    var tag: Int {
+        switch self {
+        case .invite:
+            return 2000
+        case .message:
+            return 2002
+        }
+    }
+
+    var responseTag: Int {
+        return tag + 1
+    }
+}
+
 extension JSONRPCRequest {
     init(id: Int64 = JsonRpcID.generate(), params: T) where T == ChatRequestParams {
         var method: String!

--- a/Sources/WalletConnectRelay/PublishTag.swift
+++ b/Sources/WalletConnectRelay/PublishTag.swift
@@ -1,5 +1,0 @@
-public enum PublishTag: Int {
-    case unknown = 0
-    case sign
-    case chat
-}

--- a/Sources/WalletConnectRelay/RelayClient.swift
+++ b/Sources/WalletConnectRelay/RelayClient.swift
@@ -96,10 +96,6 @@ public final class RelayClient {
     }
 
     /// Completes when networking client sends a request, error if it fails on client side
-    public func publish(topic: String, payload: String, tag: PublishTag, prompt: Bool = false) async throws {
-        try await publish(topic: topic, payload: payload, tag: tag.rawValue, prompt: prompt)
-    }
-
     public func publish(topic: String, payload: String, tag: Int, prompt: Bool = false) async throws {
         let params = RelayJSONRPC.PublishParams(topic: topic, message: payload, ttl: defaultTtl, prompt: prompt, tag: tag)
         let request = JSONRPCRequest<RelayJSONRPC.PublishParams>(method: RelayJSONRPC.Method.publish.method, params: params)
@@ -109,16 +105,6 @@ public final class RelayClient {
     }
 
     /// Completes with an acknowledgement from the relay network.
-    @discardableResult public func publish(
-        topic: String,
-        payload: String,
-        tag: PublishTag,
-        prompt: Bool = false,
-        onNetworkAcknowledge: @escaping ((Error?) -> Void)
-    ) -> Int64 {
-        publish(topic: topic, payload: payload, tag: tag.rawValue, prompt: prompt, onNetworkAcknowledge: onNetworkAcknowledge)
-    }
-
     @discardableResult public func publish(
         topic: String,
         payload: String,

--- a/Sources/WalletConnectRelay/RelayClient.swift
+++ b/Sources/WalletConnectRelay/RelayClient.swift
@@ -97,7 +97,11 @@ public final class RelayClient {
 
     /// Completes when networking client sends a request, error if it fails on client side
     public func publish(topic: String, payload: String, tag: PublishTag, prompt: Bool = false) async throws {
-        let params = RelayJSONRPC.PublishParams(topic: topic, message: payload, ttl: defaultTtl, prompt: prompt, tag: tag.rawValue)
+        try await publish(topic: topic, payload: payload, tag: tag.rawValue, prompt: prompt)
+    }
+
+    public func publish(topic: String, payload: String, tag: Int, prompt: Bool = false) async throws {
+        let params = RelayJSONRPC.PublishParams(topic: topic, message: payload, ttl: defaultTtl, prompt: prompt, tag: tag)
         let request = JSONRPCRequest<RelayJSONRPC.PublishParams>(method: RelayJSONRPC.Method.publish.method, params: params)
         logger.debug("Publishing Payload on Topic: \(topic)")
         let requestJson = try request.json()
@@ -110,8 +114,18 @@ public final class RelayClient {
         payload: String,
         tag: PublishTag,
         prompt: Bool = false,
+        onNetworkAcknowledge: @escaping ((Error?) -> Void)
+    ) -> Int64 {
+        publish(topic: topic, payload: payload, tag: tag.rawValue, prompt: prompt, onNetworkAcknowledge: onNetworkAcknowledge)
+    }
+
+    @discardableResult public func publish(
+        topic: String,
+        payload: String,
+        tag: Int,
+        prompt: Bool = false,
         onNetworkAcknowledge: @escaping ((Error?) -> Void)) -> Int64 {
-        let params = RelayJSONRPC.PublishParams(topic: topic, message: payload, ttl: defaultTtl, prompt: prompt, tag: tag.rawValue)
+        let params = RelayJSONRPC.PublishParams(topic: topic, message: payload, ttl: defaultTtl, prompt: prompt, tag: tag)
         let request = JSONRPCRequest<RelayJSONRPC.PublishParams>(method: RelayJSONRPC.Method.publish.method, params: params)
         let requestJson = try! request.json()
         logger.debug("iridium: Publishing Payload on Topic: \(topic)")

--- a/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
@@ -82,7 +82,7 @@ final class ApproveEngine {
         let proposeResponse = SessionType.ProposeResponse(relay: relay, responderPublicKey: selfPublicKey.hexRepresentation)
         let response = JSONRPCResponse<AnyCodable>(id: payload.wcRequest.id, result: AnyCodable(proposeResponse))
 
-        try await networkingInteractor.respond(topic: payload.topic, response: .response(response))
+        try await networkingInteractor.respond(topic: payload.topic, response: .response(response), tag: payload.wcRequest.responseTag)
         try await settle(topic: sessionTopic, proposal: proposal, namespaces: sessionNamespaces)
     }
 

--- a/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
@@ -87,7 +87,7 @@ final class SessionEngine {
         guard sessionStore.hasSession(forTopic: topic) else {
             throw Errors.sessionNotFound(topic: topic)
         }
-        try await networkingInteractor.respond(topic: topic, response: response)
+        try await networkingInteractor.respond(topic: topic, response: response, tag: 1109) // FIXME: Hardcoded tag
     }
 
     func emit(topic: String, event: SessionType.EventParams.Event, chainId: Blockchain) async throws {

--- a/Sources/WalletConnectSign/NetworkInteractor/NetworkInteractor.swift
+++ b/Sources/WalletConnectSign/NetworkInteractor/NetworkInteractor.swift
@@ -13,7 +13,7 @@ protocol NetworkInteracting: AnyObject {
     func requestNetworkAck(_ wcMethod: WCMethod, onTopic topic: String, completion: @escaping ((Error?) -> Void))
     /// Completes with a peer response
     func requestPeerResponse(_ wcMethod: WCMethod, onTopic topic: String, completion: ((Result<JSONRPCResponse<AnyCodable>, JSONRPCErrorResponse>) -> Void)?)
-    func respond(topic: String, response: JsonRpcResult) async throws
+    func respond(topic: String, response: JsonRpcResult, tag: Int) async throws
     func respondSuccess(payload: WCRequestSubscriptionPayload) async throws
     func respondSuccess(for payload: WCRequestSubscriptionPayload)
     func respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode) async throws
@@ -71,7 +71,7 @@ class NetworkInteractor: NetworkInteracting {
         try jsonRpcHistory.set(topic: topic, request: payload, chainId: getChainId(payload))
         let message = try serializer.serialize(topic: topic, encodable: payload)
         let prompt = shouldPrompt(payload.method)
-        try await relayClient.publish(topic: topic, payload: message, tag: .sign, prompt: prompt)
+        try await relayClient.publish(topic: topic, payload: message, tag: payload.tag, prompt: prompt)
     }
 
     func requestPeerResponse(_ wcMethod: WCMethod, onTopic topic: String, completion: ((Result<JSONRPCResponse<AnyCodable>, JSONRPCErrorResponse>) -> Void)?) {
@@ -80,7 +80,7 @@ class NetworkInteractor: NetworkInteracting {
             try jsonRpcHistory.set(topic: topic, request: payload, chainId: getChainId(payload))
             let message = try serializer.serialize(topic: topic, encodable: payload)
             let prompt = shouldPrompt(payload.method)
-            relayClient.publish(topic: topic, payload: message, tag: .sign, prompt: prompt) { [weak self] error in
+            relayClient.publish(topic: topic, payload: message, tag: payload.tag, prompt: prompt) { [weak self] error in
                 guard let self = self else {return}
                 if let error = error {
                     self.logger.error(error)
@@ -116,7 +116,7 @@ class NetworkInteractor: NetworkInteracting {
             try jsonRpcHistory.set(topic: topic, request: payload, chainId: getChainId(payload))
             let message = try serializer.serialize(topic: topic, encodable: payload)
             let prompt = shouldPrompt(payload.method)
-            relayClient.publish(topic: topic, payload: message, tag: .sign, prompt: prompt) { error in
+            relayClient.publish(topic: topic, payload: message, tag: payload.tag, prompt: prompt) { error in
                 completion(error)
             }
         } catch WalletConnectError.internal(.jsonRpcDuplicateDetected) {
@@ -126,14 +126,14 @@ class NetworkInteractor: NetworkInteracting {
         }
     }
 
-    func respond(topic: String, response: JsonRpcResult) async throws {
+    func respond(topic: String, response: JsonRpcResult, tag: Int) async throws {
         _ = try jsonRpcHistory.resolve(response: response)
 
         let message = try serializer.serialize(topic: topic, encodable: response.value)
         logger.debug("Responding....topic: \(topic)")
 
         do {
-            try await relayClient.publish(topic: topic, payload: message, tag: .sign, prompt: false)
+            try await relayClient.publish(topic: topic, payload: message, tag: tag, prompt: false)
         } catch WalletConnectError.internal(.jsonRpcDuplicateDetected) {
             logger.info("Info: Json Rpc Duplicate Detected")
         }
@@ -141,12 +141,12 @@ class NetworkInteractor: NetworkInteracting {
 
     func respondSuccess(payload: WCRequestSubscriptionPayload) async throws {
         let response = JSONRPCResponse<AnyCodable>(id: payload.wcRequest.id, result: AnyCodable(true))
-        try await respond(topic: payload.topic, response: JsonRpcResult.response(response))
+        try await respond(topic: payload.topic, response: JsonRpcResult.response(response), tag: payload.wcRequest.responseTag)
     }
 
     func respondError(payload: WCRequestSubscriptionPayload, reason: ReasonCode) async throws {
         let response = JSONRPCErrorResponse(id: payload.wcRequest.id, error: JSONRPCErrorResponse.Error(code: reason.code, message: reason.message))
-        try await respond(topic: payload.topic, response: JsonRpcResult.error(response))
+        try await respond(topic: payload.topic, response: JsonRpcResult.error(response), tag: payload.wcRequest.responseTag)
     }
 
     // TODO: Move to async

--- a/Sources/WalletConnectSign/NetworkInteractor/NetworkRelaying.swift
+++ b/Sources/WalletConnectSign/NetworkInteractor/NetworkRelaying.swift
@@ -9,10 +9,8 @@ protocol NetworkRelaying {
     var socketConnectionStatusPublisher: AnyPublisher<SocketConnectionStatus, Never> { get }
     func connect() throws
     func disconnect(closeCode: URLSessionWebSocketTask.CloseCode) throws
-    func publish(topic: String, payload: String, tag: PublishTag, prompt: Bool) async throws
     func publish(topic: String, payload: String, tag: Int, prompt: Bool) async throws
     /// - returns: request id
-    @discardableResult func publish(topic: String, payload: String, tag: PublishTag, prompt: Bool, onNetworkAcknowledge: @escaping ((Error?) -> Void)) -> Int64
     @discardableResult func publish(topic: String, payload: String, tag: Int, prompt: Bool, onNetworkAcknowledge: @escaping ((Error?) -> Void)) -> Int64
     func subscribe(topic: String, completion: @escaping (Error?) -> Void)
     func subscribe(topic: String) async throws

--- a/Sources/WalletConnectSign/NetworkInteractor/NetworkRelaying.swift
+++ b/Sources/WalletConnectSign/NetworkInteractor/NetworkRelaying.swift
@@ -10,8 +10,10 @@ protocol NetworkRelaying {
     func connect() throws
     func disconnect(closeCode: URLSessionWebSocketTask.CloseCode) throws
     func publish(topic: String, payload: String, tag: PublishTag, prompt: Bool) async throws
+    func publish(topic: String, payload: String, tag: Int, prompt: Bool) async throws
     /// - returns: request id
     @discardableResult func publish(topic: String, payload: String, tag: PublishTag, prompt: Bool, onNetworkAcknowledge: @escaping ((Error?) -> Void)) -> Int64
+    @discardableResult func publish(topic: String, payload: String, tag: Int, prompt: Bool, onNetworkAcknowledge: @escaping ((Error?) -> Void)) -> Int64
     func subscribe(topic: String, completion: @escaping (Error?) -> Void)
     func subscribe(topic: String) async throws
     /// - returns: request id

--- a/Sources/WalletConnectSign/Types/WCRequest.swift
+++ b/Sources/WalletConnectSign/Types/WCRequest.swift
@@ -144,3 +144,35 @@ extension WCRequest {
         }
     }
 }
+
+extension WCRequest {
+
+    var tag: Int {
+        switch method {
+        case .pairingDelete:
+            return 1000
+        case .pairingPing:
+            return 1002
+        case .sessionPropose:
+            return 1100
+        case .sessionSettle:
+            return 1102
+        case .sessionUpdate:
+            return 1104
+        case .sessionExtend:
+            return 1106
+        case .sessionDelete:
+            return 1112
+        case .sessionRequest:
+            return 1108
+        case .sessionPing:
+            return 1114
+        case .sessionEvent:
+            return 1110
+        }
+    }
+
+    var responseTag: Int {
+        return tag + 1
+    }
+}

--- a/Tests/ChatTests/Mocks/NetworkingInteractorMock.swift
+++ b/Tests/ChatTests/Mocks/NetworkingInteractorMock.swift
@@ -2,9 +2,12 @@ import Foundation
 @testable import Chat
 import Combine
 import WalletConnectUtils
+import WalletConnectRelay
 
 class NetworkingInteractorMock: NetworkInteracting {
-
+    var socketConnectionStatusPublisher: AnyPublisher<SocketConnectionStatus, Never> {
+        fatalError()
+    }
     let responsePublisherSubject = PassthroughSubject<ChatResponse, Never>()
     let requestPublisherSubject = PassthroughSubject<RequestSubscriptionPayload, Never>()
 
@@ -24,7 +27,7 @@ class NetworkingInteractorMock: NetworkInteracting {
 
     }
 
-    func respond(topic: String, response: JsonRpcResult) async throws {
+    func respond(topic: String, response: JsonRpcResult, tag: Int) async throws {
 
     }
 

--- a/Tests/RelayerTests/IridiumRelayTests.swift
+++ b/Tests/RelayerTests/IridiumRelayTests.swift
@@ -37,7 +37,7 @@ class IridiumRelayTests: XCTestCase {
 
     func testPublishRequestAcknowledge() {
         let acknowledgeExpectation = expectation(description: "completion with no error on iridium request acknowledge after publish")
-        let requestId = iridiumRelay.publish(topic: "", payload: "{}", tag: .unknown, onNetworkAcknowledge: { error in
+        let requestId = iridiumRelay.publish(topic: "", payload: "{}", tag: 0, onNetworkAcknowledge: { error in
             acknowledgeExpectation.fulfill()
             XCTAssertNil(error)
         })
@@ -72,7 +72,7 @@ class IridiumRelayTests: XCTestCase {
     }
 
     func testSendOnPublish() {
-        iridiumRelay.publish(topic: "", payload: "", tag: .unknown, onNetworkAcknowledge: { _ in})
+        iridiumRelay.publish(topic: "", payload: "", tag: 0, onNetworkAcknowledge: { _ in})
         XCTAssertTrue(dispatcher.sent)
     }
 

--- a/Tests/WalletConnectSignTests/Mocks/MockedRelayClient.swift
+++ b/Tests/WalletConnectSignTests/Mocks/MockedRelayClient.swift
@@ -11,14 +11,14 @@ class MockedRelayClient: NetworkRelaying {
         socketConnectionStatusPublisherSubject.eraseToAnyPublisher()
     }
 
-    func publish(topic: String, payload: String, tag: PublishTag, prompt: Bool) async throws {
+    func publish(topic: String, payload: String, tag: Int, prompt: Bool) async throws {
         self.prompt = prompt
     }
 
     var onMessage: ((String, String) -> Void)?
     var error: Error?
     var prompt = false
-    func publish(topic: String, payload: String, tag: PublishTag, prompt: Bool, onNetworkAcknowledge: @escaping ((Error?) -> Void)) -> Int64 {
+    func publish(topic: String, payload: String, tag: Int, prompt: Bool, onNetworkAcknowledge: @escaping ((Error?) -> Void)) -> Int64 {
         self.prompt = prompt
         onNetworkAcknowledge(error)
         return 0

--- a/Tests/WalletConnectSignTests/Mocks/NetworkingInteractorMock.swift
+++ b/Tests/WalletConnectSignTests/Mocks/NetworkingInteractorMock.swift
@@ -57,7 +57,7 @@ class NetworkingInteractorMock: NetworkInteracting {
         completion(error)
     }
 
-    func respond(topic: String, response: JsonRpcResult) async throws {
+    func respond(topic: String, response: JsonRpcResult, tag: Int) async throws {
         didRespondOnTopic = topic
     }
 

--- a/Tests/WalletConnectSignTests/PairingEngineTests.swift
+++ b/Tests/WalletConnectSignTests/PairingEngineTests.swift
@@ -85,6 +85,7 @@ final class PairingEngineTests: XCTestCase {
         XCTAssertEqual(publishTopic, topicA)
     }
 
+    // Flaky test: asserting `topicB` and `sessionTopic` failed once, couldn't reproduce
     @MainActor
     func testHandleSessionProposeResponse() async {
         let uri = try! await engine.create()


### PR DESCRIPTION
closes #330 

### Overview
- Implement granular tags for SDK methods.
- Remove previous `PublishTag` type.

### Reference:
https://github.com/WalletConnect/walletconnect-specs/issues/84