### PR TITLE
feat: uses concurrency to cancel obsolete runs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+concurrency:
+  # Support push/pr as event types with different behaviors each:
+  # 1. push: queue up builds by branch
+  # 2. pr: only allow one run per PR
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref_name }}
+  # If there is already a workflow running for the same pull request, cancel it
+  # For non-PR triggers queue up builds
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:    
     runs-on: macos-latest


### PR DESCRIPTION
* improvement: cancels obsolete PR runs
* Bug fix: currently `push` triggers might run in parallel and might lost context of which merge broke the build

Resolves #345 

# Testing
Not tested (copied from other working examples)