### PR TITLE
#382 auth networking interactor

### DIFF
--- a/Example/IntegrationTests/Sign/SignClientTests.swift
+++ b/Example/IntegrationTests/Sign/SignClientTests.swift
@@ -165,8 +165,7 @@ final class SignClientTests: XCTestCase {
         wallet.onSessionProposal = { [unowned self] proposal in
             Task(priority: .high) {
                 do {
-                    try await wallet.client.approve(proposalId: proposal.id, namespaces: sessionNamespaces) }
-                catch {
+                    try await wallet.client.approve(proposalId: proposal.id, namespaces: sessionNamespaces) } catch {
                     XCTFail("\(error)")
                 }
             }

--- a/Sources/Auth/Services/App/AuthRequestService.swift
+++ b/Sources/Auth/Services/App/AuthRequestService.swift
@@ -24,7 +24,7 @@ actor AuthRequestService {
         let payload = AuthPayload(requestParams: params, iat: issueAt)
         let params = AuthRequestParams(requester: requester, payloadParams: payload)
         let request = RPCRequest(method: "wc_authRequest", params: params)
-        try await networkingInteractor.request(request, topic: topic, tag: AuthRequestParams.tag)
+        try await networkingInteractor.requestNetworkAck(request, topic: topic, tag: AuthRequestParams.tag)
         try await networkingInteractor.subscribe(topic: responseTopic)
     }
 }

--- a/Sources/Auth/Services/App/AuthRespondSubscriber.swift
+++ b/Sources/Auth/Services/App/AuthRespondSubscriber.swift
@@ -21,16 +21,16 @@ class AuthRespondSubscriber {
 
     private func subscribeForResponse() {
         networkingInteractor.responsePublisher.sink { [unowned self] subscriptionPayload in
-            guard let request = rpcHistory.get(recordId: subscriptionPayload.request.id!)?.request,
+            guard let request = rpcHistory.get(recordId: subscriptionPayload.response.id!)?.request,
                   request.method == "wc_authRequest" else { return }
             networkingInteractor.unsubscribe(topic: subscriptionPayload.topic)
-            guard let cacao = try? subscriptionPayload.request.result?.get(Cacao.self) else {
+            guard let cacao = try? subscriptionPayload.response.result?.get(Cacao.self) else {
                 logger.debug("Malformed auth response params")
                 return
             }
             do {
                 try CacaoSignatureVerifier().verifySignature(cacao)
-                onResponse?(subscriptionPayload.request.id!, cacao)
+                onResponse?(subscriptionPayload.response.id!, cacao)
             } catch {
                 logger.debug("Received response with invalid signature")
             }

--- a/Sources/Auth/Services/Common/NetworkingInteractor.swift
+++ b/Sources/Auth/Services/Common/NetworkingInteractor.swift
@@ -73,10 +73,11 @@ class NetworkingInteractor: NetworkInteracting {
             let message = try serializer.serialize(topic: topic, encodable: request)
             return try await withCheckedThrowingContinuation { continuation in
                 relayClient.publish(topic: topic, payload: message, tag: tag) { error in
-                    guard let error1 = error else {
-                        fatalError("Expected non-nil result 'error1' in the non-error case")
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
                     }
-                    continuation.resume(throwing: error1)
                 }
             }
         } catch {

--- a/Sources/Auth/Services/Common/SIWEMessageFormatter.swift
+++ b/Sources/Auth/Services/Common/SIWEMessageFormatter.swift
@@ -22,9 +22,9 @@ struct SIWEMessageFormatter: SIWEMessageFormatting {
     }
 }
 
-fileprivate struct SIWEMessage: Equatable {
+private struct SIWEMessage: Equatable {
     let domain: String
-    let uri: String //aud
+    let uri: String // aud
     let address: String
     let version: Int
     let nonce: String

--- a/Sources/Auth/Services/Wallet/AuthRequestSubscriber.swift
+++ b/Sources/Auth/Services/Wallet/AuthRequestSubscriber.swift
@@ -9,7 +9,7 @@ class AuthRequestSubscriber {
     private let address: String
     private var publishers = [AnyCancellable]()
     private let messageFormatter: SIWEMessageFormatting
-    var onRequest: ((_ id: RPCID, _ message: String)->())?
+    var onRequest: ((_ id: RPCID, _ message: String)->Void)?
 
     init(networkingInteractor: NetworkInteracting,
          logger: ConsoleLogging,

--- a/Sources/Auth/Types/ResponseSubscriptionPayload.swift
+++ b/Sources/Auth/Types/ResponseSubscriptionPayload.swift
@@ -3,5 +3,5 @@ import JSONRPC
 
 struct ResponseSubscriptionPayload: Codable, Equatable {
     let topic: String
-    let request: RPCResponse
+    let response: RPCResponse
 }

--- a/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
@@ -207,7 +207,7 @@ private extension ApproveEngine {
             )
             settlingProposal = proposal
 
-            Task(priority: .high) { 
+            Task(priority: .high) {
                 try? await networkingInteractor.subscribe(topic: sessionTopic)
             }
         } catch {

--- a/Sources/WalletConnectUtils/RPCHistory.swift
+++ b/Sources/WalletConnectUtils/RPCHistory.swift
@@ -7,11 +7,11 @@ public final class RPCHistory {
             case local
             case remote
         }
-        let id: RPCID
-        let topic: String
+        public let id: RPCID
+        public let topic: String
         let origin: Origin
         public let request: RPCRequest
-        var response: RPCResponse?
+        public var response: RPCResponse?
     }
 
     enum HistoryError: Error {

--- a/Tests/AuthTests/Mocks/NetworkingInteractorMock.swift
+++ b/Tests/AuthTests/Mocks/NetworkingInteractorMock.swift
@@ -32,4 +32,8 @@ struct NetworkingInteractorMock: NetworkInteracting {
 
     }
 
+    func requestNetworkAck(_ request: RPCRequest, topic: String, tag: Int) async throws {
+
+    }
+
 }

--- a/Tests/AuthTests/SIWEMessageFormatterTests.swift
+++ b/Tests/AuthTests/SIWEMessageFormatterTests.swift
@@ -6,7 +6,6 @@ class SIWEMessageFormatterTests: XCTestCase {
     var sut: SIWEMessageFormatter!
     let address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 
-
     override func setUp() {
         sut = SIWEMessageFormatter()
     }


### PR DESCRIPTION
Add `requestNetworkAck` function that completes with an acknowledgement from the relay network.
handles incoming requests and responses to networking interactor and publishes decrypted rpc requests to subscribers