### PR TITLE
[Core] WalletConnectRouter

### DIFF
--- a/Example/DApp/SelectChain/SelectChainView.swift
+++ b/Example/DApp/SelectChain/SelectChainView.swift
@@ -2,16 +2,27 @@ import Foundation
 import UIKit
 
 class SelectChainView: UIView {
+
     let tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
         tableView.backgroundColor = .tertiarySystemBackground
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "chain")
         return tableView
     }()
+
     let connectButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("Connect", for: .normal)
         button.backgroundColor = .systemBlue
+        button.tintColor = .white
+        button.layer.cornerRadius = 8
+        return button
+    }()
+
+    let openWallet: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Open Wallet", for: .normal)
+        button.backgroundColor = .systemFill
         button.tintColor = .white
         button.layer.cornerRadius = 8
         return button
@@ -23,6 +34,7 @@ class SelectChainView: UIView {
         backgroundColor = .systemBackground
         addSubview(tableView)
         addSubview(connectButton)
+        addSubview(openWallet)
 
         subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
 
@@ -35,7 +47,12 @@ class SelectChainView: UIView {
             connectButton.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -16),
             connectButton.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
             connectButton.heightAnchor.constraint(equalToConstant: 44),
-            connectButton.widthAnchor.constraint(equalToConstant: 120)
+            connectButton.widthAnchor.constraint(equalToConstant: 120),
+
+            openWallet.bottomAnchor.constraint(equalTo: connectButton.topAnchor, constant: -16),
+            openWallet.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
+            openWallet.heightAnchor.constraint(equalToConstant: 44),
+            openWallet.widthAnchor.constraint(equalToConstant: 120)
         ])
     }
 

--- a/Example/DApp/SelectChain/SelectChainViewController.swift
+++ b/Example/DApp/SelectChain/SelectChainViewController.swift
@@ -21,6 +21,7 @@ class SelectChainViewController: UIViewController, UITableViewDataSource {
         navigationItem.title = "Available Chains"
         selectChainView.tableView.dataSource = self
         selectChainView.connectButton.addTarget(self, action: #selector(connect), for: .touchUpInside)
+        selectChainView.openWallet.addTarget(self, action: #selector(openWallet), for: .touchUpInside)
         Sign.instance.sessionSettlePublisher.sink {[unowned self] session in
             onSessionSettled?(session)
         }.store(in: &publishers)
@@ -40,6 +41,11 @@ class SelectChainViewController: UIViewController, UITableViewDataSource {
             let uri = try await Sign.instance.connect(requiredNamespaces: namespaces)
             showConnectScreen(uriString: uri!)
         }
+    }
+
+    @objc
+    private func openWallet() {
+        UIApplication.shared.open(URL(string: "walletconnectwallet://")!)
     }
 
     private func showConnectScreen(uriString: String) {

--- a/Example/ExampleApp.xcodeproj/project.pbxproj
+++ b/Example/ExampleApp.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		A5C20229287EB34C007E3188 /* AccountStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C20228287EB34C007E3188 /* AccountStorage.swift */; };
 		A5C2022B287EB89A007E3188 /* WelcomeInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C2022A287EB89A007E3188 /* WelcomeInteractor.swift */; };
 		A5C2022D287EC3F0007E3188 /* RegisterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C2022C287EC3F0007E3188 /* RegisterService.swift */; };
+		A5C4DD8728A2DE88006A626D /* WalletConnectRouter in Frameworks */ = {isa = PBXBuildFile; productRef = A5C4DD8628A2DE88006A626D /* WalletConnectRouter */; };
 		A5D85226286333D500DAF5C3 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A5D85225286333D500DAF5C3 /* Starscream */; };
 		A5D85228286333E300DAF5C3 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A5D85227286333E300DAF5C3 /* Starscream */; };
 		A5E03DF52864651200888481 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A5E03DF42864651200888481 /* Starscream */; };
@@ -305,6 +306,7 @@
 				A5AE354728A1A2AC0059AE8A /* Web3 in Frameworks */,
 				764E1D5826F8DBAB00A1FB15 /* WalletConnect in Frameworks */,
 				A5D85226286333D500DAF5C3 /* Starscream in Frameworks */,
+				A5C4DD8728A2DE88006A626D /* WalletConnectRouter in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -931,6 +933,7 @@
 				764E1D5726F8DBAB00A1FB15 /* WalletConnect */,
 				A5D85225286333D500DAF5C3 /* Starscream */,
 				A5AE354628A1A2AC0059AE8A /* Web3 */,
+				A5C4DD8628A2DE88006A626D /* WalletConnectRouter */,
 			);
 			productName = ExampleApp;
 			productReference = 764E1D3C26F8D3FC00A1FB15 /* WalletConnect Wallet.app */;
@@ -1777,6 +1780,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A5AE354528A1A2AC0059AE8A /* XCRemoteSwiftPackageReference "Web3" */;
 			productName = Web3;
+		};
+		A5C4DD8628A2DE88006A626D /* WalletConnectRouter */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WalletConnectRouter;
 		};
 		A5D85225286333D500DAF5C3 /* Starscream */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Example/ExampleApp/Wallet/WalletViewController.swift
+++ b/Example/ExampleApp/Wallet/WalletViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import WalletConnectSign
 import WalletConnectUtils
+import WalletConnectRouter
 import Web3
 import CryptoSwift
 import Combine
@@ -23,6 +24,7 @@ final class WalletViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = "Wallet"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Back", style: .plain, target: self, action: #selector(goBack))
         walletView.scanButton.addTarget(self, action: #selector(showScanner), for: .touchUpInside)
         walletView.pasteButton.addTarget(self, action: #selector(showTextInput), for: .touchUpInside)
 
@@ -46,6 +48,11 @@ final class WalletViewController: UIViewController {
             self?.pairClient(uri: inputText)
         }
         present(alert, animated: true)
+    }
+
+    @objc
+    private func goBack() {
+        Router.goBack()
     }
 
     private func showSessionProposal(_ proposal: Proposal) {

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
             name: "WalletConnectChat",
             targets: ["Chat"]),
         .library(
-            name: "WalletConnectAuth",
-            targets: ["Auth"])
+            name: "WalletConnectRouter",
+            targets: ["WalletConnectRouter"]),
     ],
     dependencies: [
         .package(url: "https://github.com/flypaper0/Web3.swift", .branch("master"))
@@ -61,6 +61,9 @@ let package = Package(
             dependencies: ["Commons"]),
         .target(
             name: "Commons",
+            dependencies: []),
+        .target(
+            name: "WalletConnectRouter",
             dependencies: []),
         .testTarget(
             name: "WalletConnectSignTests",

--- a/Sources/WalletConnectRouter/Router.m
+++ b/Sources/WalletConnectRouter/Router.m
@@ -1,0 +1,26 @@
+#import <Foundation/Foundation.h>
+#import "Router.h"
+
+@import UIKit;
+@import ObjectiveC.runtime;
+
+@interface UISystemNavigationAction : NSObject
+@property(nonatomic, readonly, nonnull) NSArray<NSNumber*>* destinations;
+-(BOOL)sendResponseForDestination:(NSUInteger)destination;
+@end
+
+@implementation Router
+
++ (void)goBack {
+    Ivar sysNavIvar = class_getInstanceVariable(UIApplication.class, "_systemNavigationAction");
+    UIApplication* app = UIApplication.sharedApplication;
+    UISystemNavigationAction* action = object_getIvar(app, sysNavIvar);
+    if (!action) {
+        return;
+    }
+    NSUInteger destination = action.destinations.firstObject.unsignedIntegerValue;
+    [action sendResponseForDestination:destination];
+}
+
+@end
+

--- a/Sources/WalletConnectRouter/include/Router.h
+++ b/Sources/WalletConnectRouter/include/Router.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Router: NSObject
++ (void)goBack;
+@end

--- a/Sources/WalletConnectRouter/include/module.modulemap
+++ b/Sources/WalletConnectRouter/include/module.modulemap
@@ -1,0 +1,3 @@
+module WalletConnectRouter {
+    header "Router.h"
+}


### PR DESCRIPTION
close #233

**What changed**

WalletConnectRouter wrap `goBack()` action for external usage. Usage example added in sample app

**Sample app**

https://user-images.githubusercontent.com/5384197/183735032-52394713-e7ab-4981-ae64-4171151a7ac6.mov

