### PR TITLE
Adds more unit tests for WCPairing

### DIFF
--- a/Tests/WalletConnectSignTests/WCPairingTests.swift
+++ b/Tests/WalletConnectSignTests/WCPairingTests.swift
@@ -75,21 +75,27 @@ final class WCPairingTests: XCTestCase {
     }
     
     func testUpdateExpiry_WhenNewExpiryDateIsLessThanExpiryDate_ShouldThrowInvalidUpdateExpiryValue() {
-        let expiryDate = referenceDate.advanced(by: 10 * .minute)
+        let expiryDate = referenceDate.advanced(by: 40 * .day)
         var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: expiryDate)
-        XCTAssertThrowsError(try pairing.updateExpiry(40 * .day)) { error in
+        XCTAssertThrowsError(try pairing.updateExpiry(10 * .minute)) { error in
             XCTAssertEqual(error as! WCPairing.Errors, WCPairing.Errors.invalidUpdateExpiryValue)
         }
     }
 
-    func testActivate_WhenUpdateExpiryFails_ShouldActivateAndThrowError() {
-        let expiryDate = referenceDate.advanced(by: 10 * .minute)
+    func testActivate_WhenCanUpdateExpiry_ShouldActivateAndUpdateExpiryIn30Days() {
+        var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: referenceDate)
+        XCTAssertFalse(pairing.active)
+        pairing.activate()
+        XCTAssertTrue(pairing.active)
+        XCTAssertEqual(referenceDate.advanced(by: 30 * .day), pairing.expiryDate)
+    }
+    
+    func testActivate_WhenUpdateExpiryIsInvalid_ShouldActivateAndNotUpdateExpiry() {
+        let expiryDate = referenceDate.advanced(by: 40 * .day)
         var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: expiryDate)
         XCTAssertFalse(pairing.active)
         pairing.activate()
-        XCTAssertThrowsError(try pairing.updateExpiry(10 * .minute)) { error in
-            XCTAssertEqual(error as! WCPairing.Errors, WCPairing.Errors.invalidUpdateExpiryValue)
-        }
         XCTAssertTrue(pairing.active)
+        XCTAssertEqual(expiryDate, pairing.expiryDate)
     }
 }

--- a/Tests/WalletConnectSignTests/WCPairingTests.swift
+++ b/Tests/WalletConnectSignTests/WCPairingTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import WalletConnectPairing
+@testable import WalletConnectPairing
 @testable import WalletConnectSign
 
 final class WCPairingTests: XCTestCase {
@@ -35,18 +35,61 @@ final class WCPairingTests: XCTestCase {
         XCTAssertEqual(pairing.expiryDate, inactiveExpiry)
     }
 
-    func testUpdateExpiry() {
+    func testUpdateExpiryForTopic() {
         var pairing = WCPairing(topic: "")
         let activeExpiry = referenceDate.advanced(by: WCPairing.timeToLiveActive)
         try? pairing.updateExpiry()
         XCTAssertEqual(pairing.expiryDate, activeExpiry)
     }
+    
+    func testUpdateExpiryForUri() {
+        var pairing = WCPairing(uri: WalletConnectURI.stub())
+        let activeExpiry = referenceDate.advanced(by: WCPairing.timeToLiveActive)
+        try? pairing.updateExpiry()
+        XCTAssertEqual(pairing.expiryDate, activeExpiry)
+    }
 
-    func testActivate() {
+    func testActivateTopic() {
         var pairing = WCPairing(topic: "")
         let activeExpiry = referenceDate.advanced(by: WCPairing.timeToLiveActive)
+        XCTAssertFalse(pairing.active)
         pairing.activate()
         XCTAssertTrue(pairing.active)
         XCTAssertEqual(pairing.expiryDate, activeExpiry)
+    }
+    
+    func testActivateURI() {
+        var pairing = WCPairing(uri: WalletConnectURI.stub())
+        let activeExpiry = referenceDate.advanced(by: WCPairing.timeToLiveActive)
+        XCTAssertFalse(pairing.active)
+        pairing.activate()
+        XCTAssertTrue(pairing.active)
+        XCTAssertEqual(pairing.expiryDate, activeExpiry)
+    }
+    
+    func testUpdateExpiry_WhenValueIsGreaterThanMax_ShouldThrowInvalidUpdateExpiryValue() {
+        var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: referenceDate)
+        XCTAssertThrowsError(try pairing.updateExpiry(40 * .day)) { error in
+            XCTAssertEqual(error as! WCPairing.Errors, WCPairing.Errors.invalidUpdateExpiryValue)
+        }
+    }
+    
+    func testUpdateExpiry_WhenNewExpiryDateIsLessThanExpiryDate_ShouldThrowInvalidUpdateExpiryValue() {
+        let expiryDate = referenceDate.advanced(by: 10 * .minute)
+        var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: expiryDate)
+        XCTAssertThrowsError(try pairing.updateExpiry(40 * .day)) { error in
+            XCTAssertEqual(error as! WCPairing.Errors, WCPairing.Errors.invalidUpdateExpiryValue)
+        }
+    }
+
+    func testActivate_WhenUpdateExpiryFails_ShouldActivateAndThrowError() {
+        let expiryDate = referenceDate.advanced(by: 10 * .minute)
+        var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: expiryDate)
+        XCTAssertFalse(pairing.active)
+        pairing.activate()
+        XCTAssertThrowsError(try pairing.updateExpiry(10 * .minute)) { error in
+            XCTAssertEqual(error as! WCPairing.Errors, WCPairing.Errors.invalidUpdateExpiryValue)
+        }
+        XCTAssertTrue(pairing.active)
     }
 }

--- a/Tests/WalletConnectSignTests/WCPairingTests.swift
+++ b/Tests/WalletConnectSignTests/WCPairingTests.swift
@@ -67,14 +67,14 @@ final class WCPairingTests: XCTestCase {
         XCTAssertEqual(pairing.expiryDate, activeExpiry)
     }
     
-    func testUpdateExpiry_WhenValueIsGreaterThanMax_ShouldThrowInvalidUpdateExpiryValue() {
+    func testUpdateExpiryWhenValueIsGreaterThanMax() {
         var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: referenceDate)
         XCTAssertThrowsError(try pairing.updateExpiry(40 * .day)) { error in
             XCTAssertEqual(error as! WCPairing.Errors, WCPairing.Errors.invalidUpdateExpiryValue)
         }
     }
     
-    func testUpdateExpiry_WhenNewExpiryDateIsLessThanExpiryDate_ShouldThrowInvalidUpdateExpiryValue() {
+    func testUpdateExpiryWhenNewExpiryDateIsLessThanExpiryDate() {
         let expiryDate = referenceDate.advanced(by: 40 * .day)
         var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: expiryDate)
         XCTAssertThrowsError(try pairing.updateExpiry(10 * .minute)) { error in
@@ -82,7 +82,7 @@ final class WCPairingTests: XCTestCase {
         }
     }
 
-    func testActivate_WhenCanUpdateExpiry_ShouldActivateAndUpdateExpiryIn30Days() {
+    func testActivateWhenCanUpdateExpiry() {
         var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: referenceDate)
         XCTAssertFalse(pairing.active)
         pairing.activate()
@@ -90,7 +90,7 @@ final class WCPairingTests: XCTestCase {
         XCTAssertEqual(referenceDate.advanced(by: 30 * .day), pairing.expiryDate)
     }
     
-    func testActivate_WhenUpdateExpiryIsInvalid_ShouldActivateAndNotUpdateExpiry() {
+    func testActivateWhenUpdateExpiryIsInvalid() {
         let expiryDate = referenceDate.advanced(by: 40 * .day)
         var pairing = WCPairing(topic: "", relay: .stub(), peerMetadata: .stub(), expiryDate: expiryDate)
         XCTAssertFalse(pairing.active)


### PR DESCRIPTION
- Rename some tests to specify if is testing init from uri or topic 
- Add scenarios that throw error 

While working on this I noticed that the `activate` function sets the status to `true` even if `updateExpiry` throws an [error](https://github.com/WalletConnect/WalletConnectSwiftV2/blob/b676369f6dd72d8d0d80fe1275313f1f74cade7b/Sources/WalletConnectPairing/Types/WCPairing.swift#L52). Is that the expected behavior? Maybe `activate` should only change the `active` var?