### PR TITLE
#454 Update `WalletConnectURI` with API identifier prefix

### DIFF
--- a/Sources/WalletConnectUtils/WalletConnectURI.swift
+++ b/Sources/WalletConnectUtils/WalletConnectURI.swift
@@ -2,42 +2,60 @@ import Foundation
 
 public struct WalletConnectURI: Equatable {
 
+    public enum TargetAPI: String, CaseIterable {
+        case sign
+        case chat
+        case auth
+    }
+
     public let topic: String
     public let version: String
     public let symKey: String
     public let relay: RelayProtocolOptions
 
-    public init(topic: String, symKey: String, relay: RelayProtocolOptions) {
+    public var api: TargetAPI {
+        apiType ?? .sign
+    }
+
+    public var absoluteString: String {
+        if let api = apiType {
+            return "wc:\(api.rawValue)-\(topic)@\(version)?symKey=\(symKey)&\(relayQuery)"
+        }
+        return "wc:\(topic)@\(version)?symKey=\(symKey)&\(relayQuery)"
+    }
+
+    private let apiType: TargetAPI?
+
+    public init(topic: String, symKey: String, relay: RelayProtocolOptions, api: TargetAPI? = nil) {
         self.version = "2"
         self.topic = topic
         self.symKey = symKey
         self.relay = relay
+        self.apiType = api
     }
 
     public init?(string: String) {
-        guard string.hasPrefix("wc:") else {
-            return nil
-        }
-        let urlString = !string.hasPrefix("wc://") ? string.replacingOccurrences(of: "wc:", with: "wc://") : string
-        guard let components = URLComponents(string: urlString) else {
+        guard let components = Self.parseURIComponents(from: string) else {
             return nil
         }
         let query: [String: String]? = components.queryItems?.reduce(into: [:]) { $0[$1.name] = $1.value }
 
-        guard let topic = components.user,
-              let version = components.host,
-              let symKey = query?["symKey"],
-              let relayProtocol = query?["relay-protocol"]
-        else { return nil }
+        guard
+            let userString = components.user,
+            let version = components.host,
+            let symKey = query?["symKey"],
+            let relayProtocol = query?["relay-protocol"]
+        else {
+            return nil
+        }
+        let uriUser = Self.parseURIUser(from: userString)
         let relayData = query?["relay-data"]
+
         self.version = version
-        self.topic = topic
+        self.topic = uriUser.topic
         self.symKey = symKey
         self.relay = RelayProtocolOptions(protocol: relayProtocol, data: relayData)
-    }
-
-    public var absoluteString: String {
-        return "wc:\(topic)@\(version)?symKey=\(symKey)&\(relayQuery)"
+        self.apiType = uriUser.api
     }
 
     private var relayQuery: String {
@@ -46,5 +64,22 @@ public struct WalletConnectURI: Equatable {
             query = "\(query)&relay-data=\(relayData)"
         }
         return query
+    }
+
+    private static func parseURIComponents(from string: String) -> URLComponents? {
+        guard string.hasPrefix("wc:") else {
+            return nil
+        }
+        let urlString = !string.hasPrefix("wc://") ? string.replacingOccurrences(of: "wc:", with: "wc://") : string
+        return URLComponents(string: urlString)
+    }
+
+    private static func parseURIUser(from string: String) -> (topic: String, api: TargetAPI?) {
+        let splits = string.split(separator: "-")
+        if splits.count == 2, let apiFromPrefix = TargetAPI(rawValue: String(splits[0])) {
+            return (String(splits[1]), apiFromPrefix)
+        } else {
+            return (string, nil)
+        }
     }
 }

--- a/Tests/WalletConnectUtilsTests/WalletConnectURITests.swift
+++ b/Tests/WalletConnectUtilsTests/WalletConnectURITests.swift
@@ -1,33 +1,48 @@
 import XCTest
 @testable import WalletConnectUtils
 
-private let stubTopic = "8097df5f14871126866252c1b7479a14aefb980188fc35ec97d130d24bd887c8"
-private let stubSymKey = "587d5484ce2a2a6ee3ba1962fdd7e8588e06200c46823bd18fbd67def96ad303"
-private let stubProtocol = "irn"
-
-private let stubURI = "wc:auth-\(stubTopic)@2?symKey=\(stubSymKey)&relay-protocol=\(stubProtocol)"
-
 final class WalletConnectURITests: XCTestCase {
+
+    var stubURI: String!
+
+    var stubTopic: String!
+    var stubSymKey: String!
+    let stubProtocol = "irn"
+
+    override func setUp() {
+        let topic = Data.randomBytes(count: 32).toHexString()
+        let symKey = Data.randomBytes(count: 32).toHexString()
+        stubTopic = topic
+        stubSymKey = symKey
+        stubURI = "wc:\(topic)@2?symKey=\(symKey)&relay-protocol=\(stubProtocol)"
+    }
+
+    override func tearDown() {
+        stubURI = nil
+        stubTopic = nil
+        stubSymKey = nil
+    }
 
     func testInitURIToString() {
         let inputURI = WalletConnectURI(
-            topic: "8097df5f14871126866252c1b7479a14aefb980188fc35ec97d130d24bd887c8",
-            symKey: "19c5ecc857963976fabb98ed6a3e0a6ab6b0d65c018b6e25fbdcd3a164def868",
-            relay: RelayProtocolOptions(protocol: "irn", data: nil))
+            topic: stubTopic,
+            symKey: stubSymKey,
+            relay: RelayProtocolOptions(protocol: stubProtocol, data: nil))
         let uriString = inputURI.absoluteString
         let outputURI = WalletConnectURI(string: uriString)
         XCTAssertEqual(inputURI, outputURI)
+        XCTAssertEqual(stubURI, outputURI?.absoluteString)
     }
 
     func testInitStringToURI() {
-        let inputURIString = stubURI
+        let inputURIString = stubURI!
         let uri = WalletConnectURI(string: inputURIString)
         let outputURIString = uri?.absoluteString
         XCTAssertEqual(inputURIString, outputURIString)
     }
 
     func testInitStringToURIAlternate() {
-        let expectedString = stubURI
+        let expectedString = stubURI!
         let inputURIString = expectedString.replacingOccurrences(of: "wc:", with: "wc://")
         let uri = WalletConnectURI(string: inputURIString)
         let outputURIString = uri?.absoluteString
@@ -49,7 +64,8 @@ final class WalletConnectURITests: XCTestCase {
     }
 
     func testInitFailsNoSymKeyParam() {
-        let inputURIString = stubURI.replacingOccurrences(of: "symKey=\(stubSymKey)", with: "")
+        let symKey = stubSymKey!
+        let inputURIString = stubURI.replacingOccurrences(of: "symKey=\(symKey)", with: "")
         let uri = WalletConnectURI(string: inputURIString)
         XCTAssertNil(uri)
     }

--- a/Tests/WalletConnectUtilsTests/WalletConnectURITests.swift
+++ b/Tests/WalletConnectUtilsTests/WalletConnectURITests.swift
@@ -1,11 +1,11 @@
 import XCTest
-@testable import WalletConnectSign
+@testable import WalletConnectUtils
 
 private let stubTopic = "8097df5f14871126866252c1b7479a14aefb980188fc35ec97d130d24bd887c8"
 private let stubSymKey = "587d5484ce2a2a6ee3ba1962fdd7e8588e06200c46823bd18fbd67def96ad303"
 private let stubProtocol = "irn"
 
-private let stubURI = "wc:7f6e504bfad60b485450578e05678ed3e8e8c4751d3c6160be17160d63ec90f9@2?symKey=587d5484ce2a2a6ee3ba1962fdd7e8588e06200c46823bd18fbd67def96ad303&relay-protocol=irn"
+private let stubURI = "wc:auth-\(stubTopic)@2?symKey=\(stubSymKey)&relay-protocol=\(stubProtocol)"
 
 final class WalletConnectURITests: XCTestCase {
 
@@ -33,6 +33,8 @@ final class WalletConnectURITests: XCTestCase {
         let outputURIString = uri?.absoluteString
         XCTAssertEqual(expectedString, outputURIString)
     }
+
+    // MARK: - Init failure cases
 
     func testInitFailsBadScheme() {
         let inputURIString = stubURI.replacingOccurrences(of: "wc:", with: "")


### PR DESCRIPTION
# Description
Updates `WalletConnectURI` to include a API prefix in its format. Implementation is backwards compatible with legacy format.

Resolves #454 

## How Has This Been Tested?
Unit tests
