### PR TITLE
[Relay] Fot fix for json rpc duplicates 

### DIFF
--- a/Example/ExampleApp/SceneDelegate.swift
+++ b/Example/ExampleApp/SceneDelegate.swift
@@ -43,8 +43,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
               }
         let wcUri = incomingURL.absoluteString.deletingPrefix("https://walletconnect.com/wc?uri=")
         let vc = ((window!.rootViewController as! UINavigationController).viewControllers[0] as! WalletViewController)
+        Task(priority: .high) {try? await Sign.instance.pair(uri: WalletConnectURI(string: wcUri)!)}
         vc.onClientConnected = {
-            Task {
+            Task(priority: .high) {
                 do {
                     try await Sign.instance.pair(uri: WalletConnectURI(string: wcUri)!)
                 } catch {

--- a/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
+++ b/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
@@ -99,8 +99,8 @@ final class RelayClientEndToEndTests: XCTestCase {
         XCTAssertEqual(subscriptionBTopic, randomTopic)
 
         // TODO - uncomment lines when request rebound is resolved
-//        XCTAssertEqual(subscriptionBPayload, payloadA)
-//        XCTAssertEqual(subscriptionAPayload, payloadB)
+        XCTAssertEqual(subscriptionBPayload, payloadA)
+        XCTAssertEqual(subscriptionAPayload, payloadB)
     }
 }
 

--- a/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
+++ b/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
@@ -98,7 +98,6 @@ final class RelayClientEndToEndTests: XCTestCase {
         XCTAssertEqual(subscriptionATopic, randomTopic)
         XCTAssertEqual(subscriptionBTopic, randomTopic)
 
-        // TODO - uncomment lines when request rebound is resolved
         XCTAssertEqual(subscriptionBPayload, payloadA)
         XCTAssertEqual(subscriptionAPayload, payloadB)
     }

--- a/Sources/WalletConnectRelay/RelayClient.swift
+++ b/Sources/WalletConnectRelay/RelayClient.swift
@@ -87,7 +87,7 @@ public final class RelayClient {
         keychainStorage: KeychainStorageProtocol = KeychainStorage(serviceIdentifier: "com.walletconnect.sdk"),
         socketFactory: WebSocketFactory,
         socketConnectionType: SocketConnectionType = .automatic,
-        logger: ConsoleLogging = ConsoleLogger(loggingLevel: .debug)
+        logger: ConsoleLogging = ConsoleLogger(loggingLevel: .off)
     ) {
         let socketAuthenticator = SocketAuthenticator(
             clientIdStorage: ClientIdStorage(keychain: keychainStorage),

--- a/Sources/WalletConnectRelay/RelayClient.swift
+++ b/Sources/WalletConnectRelay/RelayClient.swift
@@ -247,7 +247,6 @@ public final class RelayClient {
                     messagePublisherSubject.send((params.data.topic, params.data.message))
                 } catch {
                     logger.error("[RelayClient] RPC History 'set()' error: \(error)")
-                    logger.error(request.id)
                 }
             } else {
                 logger.error("Unexpected request from network")

--- a/Sources/WalletConnectRelay/RelayClient.swift
+++ b/Sources/WalletConnectRelay/RelayClient.swift
@@ -242,8 +242,8 @@ public final class RelayClient {
         if let request = tryDecode(RPCRequest.self, from: payload) {
             if let params = try? request.params?.get(Subscription.Params.self) {
                 do {
-                    try rpcHistory.set(request, forTopic: params.data.topic, emmitedBy: .remote)
                     try acknowledgeRequest(request)
+                    try rpcHistory.set(request, forTopic: params.data.topic, emmitedBy: .remote)
                     messagePublisherSubject.send((params.data.topic, params.data.message))
                 } catch {
                     logger.error("[RelayClient] RPC History 'set()' error: \(error)")

--- a/Sources/WalletConnectSign/Sign/SignClientFactory.swift
+++ b/Sources/WalletConnectSign/Sign/SignClientFactory.swift
@@ -16,7 +16,7 @@ public struct SignClientFactory {
     ///
     /// WalletConnect Client is not a singleton but once you create an instance, you should not deinitialize it. Usually only one instance of a client is required in the application.
     public static func create(metadata: AppMetadata, relayClient: RelayClient) -> SignClient {
-        let logger = ConsoleLogger(loggingLevel: .debug)
+        let logger = ConsoleLogger(loggingLevel: .off)
         let keyValueStorage = UserDefaults.standard
         let keychainStorage = KeychainStorage(serviceIdentifier: "com.walletconnect.sdk")
         return SignClientFactory.create(metadata: metadata, logger: logger, keyValueStorage: keyValueStorage, keychainStorage: keychainStorage, relayClient: relayClient)

--- a/Sources/WalletConnectSign/Sign/SignClientFactory.swift
+++ b/Sources/WalletConnectSign/Sign/SignClientFactory.swift
@@ -16,7 +16,7 @@ public struct SignClientFactory {
     ///
     /// WalletConnect Client is not a singleton but once you create an instance, you should not deinitialize it. Usually only one instance of a client is required in the application.
     public static func create(metadata: AppMetadata, relayClient: RelayClient) -> SignClient {
-        let logger = ConsoleLogger(loggingLevel: .off)
+        let logger = ConsoleLogger(loggingLevel: .debug)
         let keyValueStorage = UserDefaults.standard
         let keychainStorage = KeychainStorage(serviceIdentifier: "com.walletconnect.sdk")
         return SignClientFactory.create(metadata: metadata, logger: logger, keyValueStorage: keyValueStorage, keychainStorage: keychainStorage, relayClient: relayClient)


### PR DESCRIPTION
# Description
- hot fix for json rpc duplicates
     relay client was not acknowledging subscription requests to the relay server.
- fix issue with handling deep link by sample wallet when socket is connected
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # (issue)

## How Has This Been Tested?
manual testing and integration testing
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
