### PR TITLE
[Sign] #575 concurrent settle request and propose response

### DIFF
--- a/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
@@ -56,7 +56,6 @@ final class ApproveEngine {
     }
 
     func approveProposal(proposerPubKey: String, validating sessionNamespaces: [String: SessionNamespace]) async throws {
-        print("approving: \(Int64((Date().timeIntervalSince1970 * 1000.0).rounded()))")
         guard let payload = try proposalPayloadsStore.get(key: proposerPubKey) else {
             throw Errors.wrongRequestParams
         }
@@ -143,7 +142,6 @@ final class ApproveEngine {
 
         Task {
             try await networkingInteractor.subscribe(topic: topic)
-            print("subscription end: \(Int64((Date().timeIntervalSince1970 * 1000.0).rounded()))")
         }
         sessionStore.setSession(session)
 
@@ -151,7 +149,6 @@ final class ApproveEngine {
         let request = RPCRequest(method: protocolMethod.method, params: settleParams)
         Task {
             try await networkingInteractor.request(request, topic: topic, protocolMethod: protocolMethod)
-            print("settle sent: \(Int64((Date().timeIntervalSince1970 * 1000.0).rounded()))")
         }
         onSessionSettle?(session.publicRepresentation())
     }


### PR DESCRIPTION
# Description
Add concurrency for settle request and propose response
Speeds up sign integration tests execution by ~0.7s on local mac
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves #575 

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
