### PR TITLE
Use of unmodified Web3.swift dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
             targets: ["WalletConnectNetworking"])
     ],
     dependencies: [
-        .package(url: "https://github.com/WalletConnect/Web3.swift", .exact("1.0.0"))
+        .package(url: "https://github.com/gnosis/Web3.swift", revision: "420ce9f98b5ae2ccd9117515dda40819f5317036")
     ],
     targets: [
         .target(

--- a/Sources/Auth/Services/Signer/EIP191/EIP191Verifier.swift
+++ b/Sources/Auth/Services/Signer/EIP191/EIP191Verifier.swift
@@ -15,7 +15,14 @@ actor EIP191Verifier {
     }
 
     private func decompose(signature: Data) -> Signer.Signature {
-        let v = signature.bytes[signature.count-1]
+        var v = signature.bytes[signature.count-1]
+        if v >= 27 && v <= 30 {
+            v -= 27
+        } else if v >= 31 && v <= 34 {
+            v -= 31
+        } else if v >= 35 && v <= 38 {
+            v -= 35
+        }
         let r = signature.bytes[0..<32]
         let s = signature.bytes[32..<64]
         return (UInt(v), [UInt8](r), [UInt8](s))

--- a/Sources/Auth/Services/Signer/Signer.swift
+++ b/Sources/Auth/Services/Signer/Signer.swift
@@ -14,6 +14,6 @@ struct Signer {
     }
 
     private func serialized(signature: Signature) -> Data {
-        return Data(signature.r + signature.s + [UInt8(signature.v)])
+        return Data(signature.r + signature.s + [UInt8(signature.v + 27)])
     }
 }


### PR DESCRIPTION
# Description

The idea of this PR is to move domain-specific changes from the forked Web3.swift dependency to the WalletConnectSwiftV2 itself.

Boilertalk's Web3 implementation is quite successful and used by many projects (such as Gnosis, 1inch, etc.).
These projects often maintain their own fork of Web3.swift because its development for a long time was abandoned and had some blockers like this one https://github.com/Boilertalk/Web3.swift/pull/124/commits/182ff667d6bceccafa3d3aa64ab64f2585001b99 which was also fixed in https://github.com/WalletConnect/Web3.swift/commit/23b6940bbda0769d9147bec6696b33a9fee0b120 fork.

This particular change https://github.com/WalletConnect/Web3.swift/commit/92a43a8c279b9df25fe23dd6f8311e6fb0ea06ed makes Web3.swift  incompatible with other forks. Moreover, adding a constant 27 to the `v` is unneeded when signing EIP-1559 transactions.
For demo purposes, Gnosis' fork has been used since it's the closest to the upstream and has the described blocker [fixed](https://github.com/gnosis/Web3.swift/commit/182ff667d6bceccafa3d3aa64ab64f2585001b99).

The pull request is not fully ready since CocoaPods dependency also needs to be updated, which is impossible for someone not on their maintainers' list.

I'm open to further discussion and would be glad to get WalletConnectSwiftV2 compatibility improved.

## How Has This Been Tested?

Bundled unit tests.

## Due Diligence

This is possibly a breaking change for those who depend on the current https://github.com/WalletConnect/Web3.swift/ implementation.

* [x] Breaking change
* [ ] Requires a documentation update
