### PR TITLE
Fix: remove spurious build warning message about WalletConnectRelay/PackageConfig.json

### DIFF
--- a/WalletConnectSwiftV2.podspec
+++ b/WalletConnectSwiftV2.podspec
@@ -115,7 +115,7 @@ Pod::Spec.new do |spec|
   end
 
   spec.subspec 'WalletConnectRelay' do |ss|
-    ss.source_files = 'Sources/WalletConnectRelay/**/*'
+    ss.source_files = 'Sources/WalletConnectRelay/**/*.{h,m,swift}'
     ss.dependency 'WalletConnectSwiftV2/WalletConnectKMS'
     ss.resource_bundles = {
       'WalletConnect_WalletConnectRelay' => [


### PR DESCRIPTION
Fixes #669

Maybe a good idea to standardize `source_files` by including the same filter for all subspecs in the same `Podfile`, but this is the minimum change to address the issue.