### PR TITLE
Ensure application state read from main thread

### DIFF
--- a/Sources/WalletConnectRelay/AppStateObserving.swift
+++ b/Sources/WalletConnectRelay/AppStateObserving.swift
@@ -11,7 +11,7 @@ enum ApplicationState {
 }
 
 protocol AppStateObserving: AnyObject {
-    var currentState: ApplicationState { get }
+    var currentState: ApplicationState { get async }
     var onWillEnterForeground: (() -> Void)? {get set}
     var onWillEnterBackground: (() -> Void)? {get set}
 }
@@ -26,14 +26,17 @@ class AppStateObserver: AppStateObserving {
         subscribeNotificationCenter()
     }
 
-    var currentState: ApplicationState {
+    @MainActor
+    var currentState: ApplicationState{
+        get async {
 #if canImport(UIKit)
-        let isActive = UIApplication.shared.applicationState == .active
-        return isActive ? .foreground : .background
+            let isActive = UIApplication.shared.applicationState == .active
+            return isActive ? .foreground : .background
 #elseif canImport(AppKit)
-        let isActive = NSApplication.shared.isActive
-        return isActive ? .foreground : .background
+            let isActive = NSApplication.shared.isActive
+            return isActive ? .foreground : .background
 #endif
+        }
     }
 
     private func subscribeNotificationCenter() {

--- a/Sources/WalletConnectRelay/SocketConnectionHandler/AutomaticSocketConnectionHandler.swift
+++ b/Sources/WalletConnectRelay/SocketConnectionHandler/AutomaticSocketConnectionHandler.swift
@@ -81,7 +81,8 @@ extension AutomaticSocketConnectionHandler: SocketConnectionHandler {
     }
 
     func handleDisconnection() {
-        if appStateObserver.currentState == .foreground {
+        Task {
+            guard await appStateObserver.currentState == .foreground else { return }
             reconnectIfNeeded()
         }
     }

--- a/Tests/RelayerTests/AutomaticSocketConnectionHandlerTests.swift
+++ b/Tests/RelayerTests/AutomaticSocketConnectionHandlerTests.swift
@@ -55,12 +55,15 @@ final class AutomaticSocketConnectionHandlerTests: XCTestCase {
         XCTAssertFalse(webSocketSession.isConnected)
     }
 
-    func testReconnectOnDisconnectForeground() {
+    func testReconnectOnDisconnectForeground() async {
         appStateObserver.currentState = .foreground
         XCTAssertTrue(webSocketSession.isConnected)
         webSocketSession.disconnect()
         sut.handleDisconnection()
-        XCTAssertTrue(webSocketSession.isConnected)
+        Task { @MainActor in
+            // Simulate time for reconnect
+            XCTAssertTrue(webSocketSession.isConnected)
+        }
     }
 
     func testReconnectOnDisconnectBackground() {

--- a/Tests/RelayerTests/AutomaticSocketConnectionHandlerTests.swift
+++ b/Tests/RelayerTests/AutomaticSocketConnectionHandlerTests.swift
@@ -55,15 +55,18 @@ final class AutomaticSocketConnectionHandlerTests: XCTestCase {
         XCTAssertFalse(webSocketSession.isConnected)
     }
 
-    func testReconnectOnDisconnectForeground() async {
+    func testReconnectOnDisconnectForeground() {
+        let expectation = expectation(description: "expects to reconnect on disconnect")
         appStateObserver.currentState = .foreground
         XCTAssertTrue(webSocketSession.isConnected)
         webSocketSession.disconnect()
         sut.handleDisconnection()
-        Task { @MainActor in
-            // Simulate time for reconnect
-            XCTAssertTrue(webSocketSession.isConnected)
+        DispatchQueue.main.async {
+            // Simulate reconnect time by asserting in next runloop
+            XCTAssertTrue(self.webSocketSession.isConnected)
+            expectation.fulfill()
         }
+        waitForExpectations(timeout: 0.1, handler: nil)
     }
 
     func testReconnectOnDisconnectBackground() {


### PR DESCRIPTION
# Description

When providing a background thread to the socket factory instance, the underlying `AppStateObserver.currentState` logic calls `UIApplication.shared.applicationState` which needs to be called on the main thread.

The primary change is within the `AppStateObserving` protocol: the `currentState` property was made `async` so implementors can add the `@MainActor` property wrapper or manually run a `Task` on the main thread.

Resolves #685

## How Has This Been Tested?

1. For `DefaultSocketFactory` in the `ExampleApp`, a background thread was provided to the web socket instance:

```swift
let socket = WebSocket(url: url)
socket.callbackQueue = DispatchQueue.global()
return socket
```

The runtime warning in Xcode was observed stating `UIApplication.applicationState must be used from the main thread only`. The warning went away after the fix including going to and from the background state.

2. Unit tests had succeeded, but uncovered an issue in `RelayerTests: AutomaticSocketConnectionHandlerTests testReconnectOnDisconnectForeground` that required a change.

Because the tests assume that the socket is synchronous, the reconnect is assumed to happen instantly after disconnect. I had to simulate some time for the reconnect before checking the `isConnect` flag within the test:

```swift
Task { @MainActor in
    // Simulate time for reconnect
    XCTAssertTrue(webSocketSession.isConnected)
}
```

A better (but larger) fix for tests may be to make `WebSocketMock` asynchronous to more closely simulate real world connections. The tests would be more robust but would require a lot of changes such as making `WebSocketConnecting.isConnect` an `async` property or maybe tests should check for connection state within `socketConnectionStatusPublisher` instead.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
