### PR TITLE
[CI] Make test topic value compliant with new relay topic policies

### DIFF
--- a/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
+++ b/Example/IntegrationTests/Relay/RelayClientEndToEndTests.swift
@@ -33,7 +33,7 @@ final class RelayClientEndToEndTests: XCTestCase {
         subscribeExpectation.assertForOverFulfill = true
         relayClient.socketConnectionStatusPublisher.sink { status in
             if status == .connected {
-                relayClient.subscribe(topic: "qwerty") { error in
+                relayClient.subscribe(topic: "ecb78f2df880c43d3418ddbf871092b847801932e21765b250cc50b9e96a9131") { error in
                     XCTAssertNil(error)
                     subscribeExpectation.fulfill()
                 }


### PR DESCRIPTION
The problem description is in the thread - https://walletconnect.slack.com/archives/C03S6NN8NHF/p1675357050503549
_The value used for the topic is randomly generated_ 
* [ ] Breaking change
* [ ] Requires a documentation update
