### PR TITLE
Pass request.id to the RPCRequest

### DIFF
--- a/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
@@ -61,7 +61,7 @@ final class SessionEngine {
         let chainRequest = SessionType.RequestParams.Request(method: request.method, params: request.params, expiry: request.expiry)
         let sessionRequestParams = SessionType.RequestParams(request: chainRequest, chainId: request.chainId)
         let protocolMethod = SessionRequestProtocolMethod(ttl: request.calculateTtl())
-        let rpcRequest = RPCRequest(method: protocolMethod.method, params: sessionRequestParams)
+        let rpcRequest = RPCRequest(method: protocolMethod.method, params: sessionRequestParams, rpcid: request.id)
         try await networkingInteractor.request(rpcRequest, topic: request.topic, protocolMethod: SessionRequestProtocolMethod())
     }
 


### PR DESCRIPTION
Based on the OpenSea research:
The RPCRequest constructor in the SessionEngine is regenerating the id.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
