### PR TITLE
Expose new methods to web3wallet

### DIFF
--- a/Sources/WalletConnectPairing/PairingClientProtocol.swift
+++ b/Sources/WalletConnectPairing/PairingClientProtocol.swift
@@ -1,4 +1,5 @@
 public protocol PairingClientProtocol {
     func pair(uri: WalletConnectURI) async throws
     func disconnect(topic: String) async throws
+    func getPairings() -> [Pairing]
 }

--- a/Sources/WalletConnectSign/Sign/SignClientProtocol.swift
+++ b/Sources/WalletConnectSign/Sign/SignClientProtocol.swift
@@ -5,6 +5,10 @@ public protocol SignClientProtocol {
     var sessionProposalPublisher: AnyPublisher<Session.Proposal, Never> { get }
     var sessionRequestPublisher: AnyPublisher<Request, Never> { get }
     var sessionsPublisher: AnyPublisher<[Session], Never> { get }
+    var socketConnectionStatusPublisher: AnyPublisher<SocketConnectionStatus, Never> { get }
+    var sessionSettlePublisher: AnyPublisher<Session, Never> { get }
+    var sessionDeletePublisher: AnyPublisher<(String, Reason), Never> { get }
+    var sessionResponsePublisher: AnyPublisher<Response, Never> { get }
     
     func approve(proposalId: String, namespaces: [String: SessionNamespace]) async throws
     func reject(proposalId: String, reason: RejectionReason) async throws
@@ -15,6 +19,7 @@ public protocol SignClientProtocol {
     func pair(uri: WalletConnectURI) async throws
     func disconnect(topic: String) async throws
     func getSessions() -> [Session]
+    func cleanup() async throws
     
     func getPendingRequests(topic: String?) -> [Request]
     func getSessionRequestRecord(id: RPCID) -> Request?

--- a/Sources/Web3Wallet/Web3WalletClient.swift
+++ b/Sources/Web3Wallet/Web3WalletClient.swift
@@ -36,6 +36,32 @@ public class Web3WalletClient {
     public var sessionsPublisher: AnyPublisher<[Session], Never> {
         signClient.sessionsPublisher.eraseToAnyPublisher()
     }
+    
+    /// Publisher that sends web socket connection status
+    public var socketConnectionStatusPublisher: AnyPublisher<SocketConnectionStatus, Never> {
+        signClient.socketConnectionStatusPublisher.eraseToAnyPublisher()
+    }
+    
+    /// Publisher that sends session when one is settled
+    ///
+    /// Event is emited on proposer and responder client when both communicating peers have successfully established a session.
+    public var sessionSettlePublisher: AnyPublisher<Session, Never> {
+        signClient.sessionSettlePublisher.eraseToAnyPublisher()
+    }
+    
+    /// Publisher that sends deleted session topic
+    ///
+    /// Event can be emited on any type of the client.
+    public var sessionDeletePublisher: AnyPublisher<(String, Reason), Never> {
+        signClient.sessionDeletePublisher.eraseToAnyPublisher()
+    }
+    
+    /// Publisher that sends response for session request
+    ///
+    /// In most cases that event will be emited on dApp client.
+    public var sessionResponsePublisher: AnyPublisher<Response, Never> {
+        signClient.sessionResponsePublisher.eraseToAnyPublisher()
+    }
 
     // MARK: - Private Properties
     private let authClient: AuthClientProtocol
@@ -175,5 +201,16 @@ public class Web3WalletClient {
     /// - Returns: Pending authentication requests
     public func getPendingRequests() throws -> [AuthRequest] {
         try authClient.getPendingRequests()
+    }
+    
+    /// Delete all stored data such as: pairings, sessions, keys
+    ///
+    /// - Note: Will unsubscribe from all topics
+    public func cleanup() async throws {
+        try await signClient.cleanup()
+    }
+    
+    public func getPairings() -> [Pairing] {
+        return pairingClient.getPairings()
     }
 }

--- a/Tests/Web3WalletTests/Mocks/PairingClientMock.swift
+++ b/Tests/Web3WalletTests/Mocks/PairingClientMock.swift
@@ -14,4 +14,8 @@ final class PairingClientMock: PairingClientProtocol {
     func disconnect(topic: String) async throws {
         disconnectPairingCalled = true
     }
+    
+    func getPairings() -> [Pairing] {
+        return [Pairing(topic: "", peer: nil, expiryDate: Date())]
+    }
 }

--- a/Tests/Web3WalletTests/Mocks/ReasonMock.swift
+++ b/Tests/Web3WalletTests/Mocks/ReasonMock.swift
@@ -1,0 +1,12 @@
+import Foundation
+import WalletConnectSign
+
+struct ReasonMock: WalletConnectNetworking.Reason {
+    var code: Int {
+        return 0
+    }
+
+    var message: String {
+        return "error"
+    }
+}

--- a/Tests/Web3WalletTests/Web3WalletTests.swift
+++ b/Tests/Web3WalletTests/Web3WalletTests.swift
@@ -84,6 +84,66 @@ final class Web3WalletTests: XCTestCase {
         }
     }
     
+    func testSocketConnectionStatusCalled() {
+        var success = false
+        web3WalletClient.socketConnectionStatusPublisher.sink { value in
+            success = true
+            XCTAssertTrue(true)
+        }
+        .store(in: &disposeBag)
+        
+        let expectation = expectation(description: "Fail after 0.1s timeout")
+        let result = XCTWaiter.wait(for: [expectation], timeout: 0.1)
+        if result == XCTWaiter.Result.timedOut && success == false {
+            XCTFail()
+        }
+    }
+    
+    func testSessionSettleCalled() {
+        var success = false
+        web3WalletClient.sessionSettlePublisher.sink { value in
+            success = true
+            XCTAssertTrue(true)
+        }
+        .store(in: &disposeBag)
+        
+        let expectation = expectation(description: "Fail after 0.1s timeout")
+        let result = XCTWaiter.wait(for: [expectation], timeout: 0.1)
+        if result == XCTWaiter.Result.timedOut && success == false {
+            XCTFail()
+        }
+    }
+    
+    func testSessionDeleteCalled() {
+        var success = false
+        web3WalletClient.sessionDeletePublisher.sink { value in
+            success = true
+            XCTAssertTrue(true)
+        }
+        .store(in: &disposeBag)
+        
+        let expectation = expectation(description: "Fail after 0.1s timeout")
+        let result = XCTWaiter.wait(for: [expectation], timeout: 0.1)
+        if result == XCTWaiter.Result.timedOut && success == false {
+            XCTFail()
+        }
+    }
+    
+    func testSessionResponseCalled() {
+        var success = false
+        web3WalletClient.sessionResponsePublisher.sink { value in
+            success = true
+            XCTAssertTrue(true)
+        }
+        .store(in: &disposeBag)
+        
+        let expectation = expectation(description: "Fail after 0.1s timeout")
+        let result = XCTWaiter.wait(for: [expectation], timeout: 0.1)
+        if result == XCTWaiter.Result.timedOut && success == false {
+            XCTFail()
+        }
+    }
+    
     func testApproveCalled() async {
         try! await web3WalletClient.approve(proposalId: "", namespaces: [:])
         XCTAssertTrue(signClient.approveCalled)
@@ -193,5 +253,14 @@ final class Web3WalletTests: XCTestCase {
     func testAuthPendingRequestsCalledAndNotEmpty() async {
         let pendingRequests = try! web3WalletClient.getPendingRequests()
         XCTAssertEqual(1, pendingRequests.count)
+    }
+    
+    func testCleanupCalled() async {
+        try! await web3WalletClient.cleanup()
+        XCTAssertTrue(signClient.cleanupCalled)
+    }
+    
+    func testGetPairingsNotEmpty() async {
+        XCTAssertEqual(1, web3WalletClient.getPairings().count)
     }
 }


### PR DESCRIPTION
## Due Dilligence
Related to the [topic](https://walletconnect.slack.com/archives/C03T13E862C/p1676732936891759?thread_ts=1675969575.182249&cid=C03T13E862C):
```
Hey guys, related to Web3Wallet on iOS.
There are a lot of methods/combine publishers that we're currently using (From Sign and Pair targets) but they are not included in the Web3Wallet target and we need to import the other packages in order to make it work
Can we include them in the new SDK?

Sign
socketConnectionStatusPublisher
sessionSettlePublisher
sessionDeletePublisher
sessionResponsePublisher
cleanup

Pair
getPairings()
```
* [ ] Breaking change
* [ ] Requires a documentation update
