### PR TITLE
Comply with CAIP10 regex

### DIFF
--- a/Sources/WalletConnectUtils/Extensions/String+CAIPs.swift
+++ b/Sources/WalletConnectUtils/Extensions/String+CAIPs.swift
@@ -4,7 +4,7 @@ extension String {
 
     static let chainNamespaceRegex = "^[-a-z0-9]{3,8}$"
     static let chainReferenceRegex = "^[-a-zA-Z0-9_]{1,32}$"
-    static let accountAddressRegex = "^[a-zA-Z0-9]{1,64}$"
+    static let accountAddressRegex = "^[-.%a-zA-Z0-9]{1,128}$"
 
     static func conformsToCAIP2(_ string: String) -> Bool {
         let splits = string.split(separator: ":", omittingEmptySubsequences: false)


### PR DESCRIPTION
# Description

Describe the bug
The address in the blockchain that we would like to support via WalletConnect contains a :
(e.g. 0:38d4c6ef92bd7ff4426eb232af3ff87bea525eff112f93eb28069e54bca89e4b),
so your conformsToCAIP10 function will not pass this address because regex is not support CAIP-10: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md#syntax

To avoid this problem, we replaced : with %3A (encoding from the ASCII table), but then your regular will not resolve %.

Can you please tell me what manual you used to write this regular? What I can see from the CAIP description in the Syntax section regarding account_id- I see that their regular supports the % symbol - [-.%a-zA-Z0-9]{1,128}.

Thanks in advance for your attention!