### PR TITLE
[Core] CAIP-10 regex fixed

### DIFF
--- a/Sources/WalletConnectUtils/Extensions/String+CAIPs.swift
+++ b/Sources/WalletConnectUtils/Extensions/String+CAIPs.swift
@@ -4,7 +4,7 @@ extension String {
 
     static let chainNamespaceRegex = "^[-a-z0-9]{3,8}$"
     static let chainReferenceRegex = "^[-a-zA-Z0-9_]{1,32}$"
-    static let accountAddressRegex = "^[a-zA-Z0-9]{1,64}$"
+    static let accountAddressRegex = "^[-.%a-zA-Z0-9]{1,128}$"
 
     static func conformsToCAIP2(_ string: String) -> Bool {
         let splits = string.split(separator: ":", omittingEmptySubsequences: false)

--- a/Tests/WalletConnectUtilsTests/String+ExtensionTests.swift
+++ b/Tests/WalletConnectUtilsTests/String+ExtensionTests.swift
@@ -47,10 +47,10 @@ final class StringExtensionTests: XCTestCase {
     func testConformanceToCAIP10() {
         // Minimum and maximum length cases
         XCTAssertTrue(String.conformsToCAIP10("std:0:0"), "Dummy min length (3+1+1+1+1 = 7 chars/bytes)")
-        XCTAssertTrue(String.conformsToCAIP10("chainstd:8c3444cf8970a9e41a706fab93e7a6c4:6d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f7"), "Dummy max length (64+1+8+1+32 = 106 chars/bytes)")
+        XCTAssertTrue(String.conformsToCAIP10("chainstd:8c3444cf8970a9e41a706fab93e7a6c4:6d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f76d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f7"), "Dummy max length (8+1+32+1+128 = 170 chars/bytes)")
 
         // Invalid address formatting
-        XCTAssertFalse(String.conformsToCAIP10("chainstd:0:6d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f77"), "Address overflow")
+        XCTAssertFalse(String.conformsToCAIP10("chainstd:0:6d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f76d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f7f"), "Address overflow")
         XCTAssertFalse(String.conformsToCAIP10("chainstd:0:$"), "Address uses special character")
         XCTAssertFalse(String.conformsToCAIP10("chainstd:0:"), "Empty address")
 


### PR DESCRIPTION
# Description
CAIP-10 Regex updated with https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md#syntax
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves https://github.com/WalletConnect/WalletConnectSwiftV2/pull/761

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
