### PR TITLE
Move `fatalError()` call before `return` otherwise it never gets called

### DIFF
--- a/Sources/WalletConnectVerify/AttestChallengeProvider.swift
+++ b/Sources/WalletConnectVerify/AttestChallengeProvider.swift
@@ -6,7 +6,7 @@ protocol AttestChallengeProviding {
 
 class AttestChallengeProvider: AttestChallengeProviding {
     func getChallenge() async throws -> Data {
-        return Data()
         fatalError("not implemented")
+        return Data()
     }
 }


### PR DESCRIPTION
This also removes the build warning:

> Code after 'return' will never be executed

The pre-PR state is only correct if the `fatalError()` call was only meant to be a marked to be grepped and not intended to crash at dev/runtime