### PR TITLE
Switch try! for try in NetworkingInteractor respond method

### DIFF
--- a/Sources/WalletConnectNetworking/NetworkingInteractor.swift
+++ b/Sources/WalletConnectNetworking/NetworkingInteractor.swift
@@ -111,7 +111,7 @@ public class NetworkingInteractor: NetworkInteracting {
 
     public func respond(topic: String, response: RPCResponse, protocolMethod: ProtocolMethod, envelopeType: Envelope.EnvelopeType) async throws {
         try rpcHistory.resolve(response)
-        let message = try! serializer.serialize(topic: topic, encodable: response, envelopeType: envelopeType)
+        let message = try serializer.serialize(topic: topic, encodable: response, envelopeType: envelopeType)
         try await relayClient.publish(topic: topic, payload: message, tag: protocolMethod.responseConfig.tag, prompt: protocolMethod.responseConfig.prompt, ttl: protocolMethod.responseConfig.ttl)
     }
 


### PR DESCRIPTION
# Description
In `NetworkingInteractor` `func respond(topic, response, protocolMethod, envelopeType)` is marked with `throws`, but there was still `try!` which would sometimes fail and crash the app, since method is marked with throws there should be no need to crash the app if try fails with `WalletConnectKMS.Serializer.Errors.symmetricKeyForTopicNotFound` error
