### PR TITLE
[DApp, WalletApp] add uri encoding

### DIFF
--- a/Example/DApp/Sign/Connect/ConnectViewController.swift
+++ b/Example/DApp/Sign/Connect/ConnectViewController.swift
@@ -63,7 +63,8 @@ class ConnectViewController: UIViewController, UITableViewDataSource, UITableVie
     }
 
     @objc func connectWithExampleWallet() {
-        let url = URL(string: "https://walletconnect.com/wc?uri=\(uri.absoluteString)")!
+		let encodedUri = uri.absoluteString.addingPercentEncoding(withAllowedCharacters: .rfc3986)!
+        let url = URL(string: "walletapp://wc?uri=\(encodedUri)")!
         DispatchQueue.main.async {
             UIApplication.shared.open(url, options: [:]) { [weak self] _ in
                 self?.dismiss(animated: true, completion: nil)

--- a/Example/DApp/Sign/Connect/ConnectViewController.swift
+++ b/Example/DApp/Sign/Connect/ConnectViewController.swift
@@ -63,8 +63,7 @@ class ConnectViewController: UIViewController, UITableViewDataSource, UITableVie
     }
 
     @objc func connectWithExampleWallet() {
-		let encodedUri = uri.absoluteString.addingPercentEncoding(withAllowedCharacters: .rfc3986)!
-        let url = URL(string: "walletapp://wc?uri=\(encodedUri)")!
+        let url = URL(string: "walletapp://wc?uri=\(uri.deeplinkUri)")!
         DispatchQueue.main.async {
             UIApplication.shared.open(url, options: [:]) { [weak self] _ in
                 self?.dismiss(animated: true, completion: nil)

--- a/Example/ExampleApp.xcodeproj/project.pbxproj
+++ b/Example/ExampleApp.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		A5E22D222840C8D300E36487 /* WalletEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E22D212840C8D300E36487 /* WalletEngine.swift */; };
 		A5E22D242840C8DB00E36487 /* SafariEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E22D232840C8DB00E36487 /* SafariEngine.swift */; };
 		A5E22D2C2840EAC300E36487 /* XCUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E22D2B2840EAC300E36487 /* XCUIElement.swift */; };
+		A74D32BA2A1E25AD00CB8536 /* QueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74D32B92A1E25AD00CB8536 /* QueryParameters.swift */; };
 		C5133A78294125CC00A8314C /* Web3 in Frameworks */ = {isa = PBXBuildFile; productRef = C5133A77294125CC00A8314C /* Web3 */; };
 		C53AA4362941251C008EA57C /* DefaultSignerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59CF4F5292F83D50031A42F /* DefaultSignerFactory.swift */; };
 		C55D347F295DD7140004314A /* AuthRequestModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55D347A295DD7140004314A /* AuthRequestModule.swift */; };
@@ -508,6 +509,7 @@
 		A5E22D232840C8DB00E36487 /* SafariEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariEngine.swift; sourceTree = "<group>"; };
 		A5E22D2B2840EAC300E36487 /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
 		A5F48A0528E43D3F0034CBFB /* Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Configuration.xcconfig; path = ../Configuration.xcconfig; sourceTree = "<group>"; };
+		A74D32B92A1E25AD00CB8536 /* QueryParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryParameters.swift; sourceTree = "<group>"; };
 		C55D347A295DD7140004314A /* AuthRequestModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRequestModule.swift; sourceTree = "<group>"; };
 		C55D347B295DD7140004314A /* AuthRequestPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRequestPresenter.swift; sourceTree = "<group>"; };
 		C55D347C295DD7140004314A /* AuthRequestRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRequestRouter.swift; sourceTree = "<group>"; };
@@ -1616,6 +1618,7 @@
 			children = (
 				C56EE2A2293F6BAF004840D1 /* UIPasteboardWrapper.swift */,
 				C55D349A2965BC2F0004314A /* TagsView.swift */,
+				A74D32B92A1E25AD00CB8536 /* QueryParameters.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2221,6 +2224,7 @@
 				C56EE276293F56D7004840D1 /* UIViewController.swift in Sources */,
 				C56EE275293F56D7004840D1 /* InputConfig.swift in Sources */,
 				C55D3493295DFA750004314A /* WelcomeModule.swift in Sources */,
+				A74D32BA2A1E25AD00CB8536 /* QueryParameters.swift in Sources */,
 				C56EE270293F56D7004840D1 /* String.swift in Sources */,
 				C56EE279293F56D7004840D1 /* Color.swift in Sources */,
 				847BD1E6298A806800076C90 /* NotificationsRouter.swift in Sources */,

--- a/Example/WalletApp/ApplicationLayer/SceneDelegate.swift
+++ b/Example/WalletApp/ApplicationLayer/SceneDelegate.swift
@@ -39,10 +39,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         guard let context = URLContexts.first else { return }
 
-        let uri = context.url.absoluteString.replacingOccurrences(of: "walletapp://wc?uri=", with: "")
-        Task {
-            try await Pair.instance.pair(uri: WalletConnectURI(string: uri)!)
-        }
-
+		let queryParams = context.url.queryParameters
+		
+		if let uri = queryParams["uri"] as? String {
+			Task {
+				try await Pair.instance.pair(uri: WalletConnectURI(string: uri)!)
+			}
+		}
     }
 }

--- a/Example/WalletApp/Common/Helpers/QueryParameters.swift
+++ b/Example/WalletApp/Common/Helpers/QueryParameters.swift
@@ -1,0 +1,20 @@
+//
+//  QueryParameters.swift
+//  WalletApp
+//
+//  Created by Aleksandr Maltsev on 24.05.2023.
+//
+
+import Foundation
+
+extension URL {
+	var queryParameters: [AnyHashable: Any] {
+		let urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false)
+		guard let queryItems = urlComponents?.queryItems else { return [:] }
+		var queryParams: [AnyHashable: Any] = [:]
+		queryItems.forEach {
+			queryParams[$0.name] = $0.value
+		}
+		return queryParams
+	}
+}


### PR DESCRIPTION
# Description

* added uri percent encoding in dapp. This is necessary in order to parse universal link with wallet connect pairing uri parameter in real applications. Pairing uri contains extra '?' which fails normal query parameters parsing.
* improved pairing uri parsing in WalletApp with query parameters handling.

# Resolves (issue) 

It resolves inability to send correct pairing uri via universal link on iOS.

<!-- If valid for smoke test on feature add screenshots -->

## How Has This Been Tested?

* you can try to connect dapp without percent encoding to any mobile wallet (e.g. TrustWallet)
* repeat it with percent encoding

## Due Dilligence

* [ ] Requires a documentation update. It would be nice to update your documentation by [link](https://docs.walletconnect.com/2.0/ios/guides/mobile-linking) in 'iOS Wallet support' and provide correct universal link for with uri encoding.
