### PR TITLE
[Docs] Generate and Deploy DocC to GH pages

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -1,0 +1,45 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", 'docs']
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Generate docs
+        shell: bash
+        run: |
+          ./generate_docs.sh
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload just docs directory
+          path: 'docs'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main", 'docs']
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -74,6 +74,24 @@
         }
       },
       {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "26ac5758409154cc448d7ab82389c520fa8a8247",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "SymbolKit",
+        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
+        "state": {
+          "branch": null,
+          "revision": "b45d1f2ed151d057b54504d653e0da5552844e34",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "swift-qrcode-generator",
         "repositoryURL": "https://github.com/dagronf/swift-qrcode-generator",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,52 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "QRCode",
+        "repositoryURL": "https://github.com/WalletConnect/QRCode",
+        "state": {
+          "branch": null,
+          "revision": "263f280d2c8144adfb0b6676109846cfc8dd552b",
+          "version": "14.3.1"
+        }
+      },
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "26ac5758409154cc448d7ab82389c520fa8a8247",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "SymbolKit",
+        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
+        "state": {
+          "branch": null,
+          "revision": "b45d1f2ed151d057b54504d653e0da5552844e34",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-qrcode-generator",
+        "repositoryURL": "https://github.com/dagronf/swift-qrcode-generator",
+        "state": {
+          "branch": null,
+          "revision": "5ca09b6a2ad190f94aa3d6ddef45b187f8c0343b",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "package": "SwiftImageReadWrite",
+        "repositoryURL": "https://github.com/dagronf/SwiftImageReadWrite",
+        "state": {
+          "branch": null,
+          "revision": "5596407d1cf61b953b8e658fa8636a471df3c509",
+          "version": "1.1.6"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "WalletConnect",
     platforms: [
         .iOS(.v14),
-        .macOS(.v11),
+        .macOS(.v12),
         .tvOS(.v14)
     ],
     products: [
@@ -55,6 +55,7 @@ let package = Package(
 
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
         .package(url: "https://github.com/WalletConnect/QRCode", from: "14.3.1")
     ],
     targets: [
@@ -134,7 +135,10 @@ let package = Package(
             name: "WalletConnectModal",
             dependencies: ["QRCode", "WalletConnectSign"],
             exclude: ["Secrets/secrets.json.sample"],
-            resources: [.copy("Secrets/secrets.json")]
+            resources: [
+                .copy("Secrets/secrets.json"),
+                .copy("Resources/Assets.xcassets")
+            ]
         ),
         .target(
             name: "WalletConnectSync",

--- a/Sources/Web3Inbox/WebView/WebViewFactory.swift
+++ b/Sources/Web3Inbox/WebView/WebViewFactory.swift
@@ -13,7 +13,9 @@ final class WebViewFactory {
 
     func create() -> WKWebView {
         let configuration = WKWebViewConfiguration()
+        #if os(iOS)
         configuration.allowsInlineMediaPlayback = true
+        #endif
         configuration.userContentController.add(
             webviewSubscriber,
             name: WebViewRequestSubscriber.chat

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+DOCS_BASE_DIR="./docs"
+
+dump=$(swift package dump-package | jq -r '.targets[].name')
+
+IFS=$'\n' read -rd '' -a TARGETS <<<"$dump"
+
+mkdir -p tmp-doc
+
+for target in "${TARGETS[@]}"; do
+    swift package --allow-writing-to-directory "./tmp-doc/${target}-docs" \
+        generate-documentation \
+        --target $target \
+        --disable-indexing \
+        --include-extended-types \
+        --output-path "./tmp-doc/${target}-docs" \
+        --hosting-base-path WalletConnectSwiftV2
+done
+
+rm -rf ${DOCS_BASE_DIR}
+is_first=1
+for target in "${TARGETS[@]}"; do
+    if [ $is_first -eq 1 ]; then
+        echo "Copying initial documentation for ${target}"
+        cp -R "tmp-doc/${target}-docs" "${DOCS_BASE_DIR}"
+        is_first=0
+    else
+        echo "Merging documentation for ${target}"
+        cp -R "tmp-doc/${target}-docs/data/documentation/"* "${DOCS_BASE_DIR}/data/documentation/"
+        cp -R "tmp-doc/${target}-docs/documentation/"* "${DOCS_BASE_DIR}/documentation/"
+    fi
+done
+echo "Deleting non-mergable metadata.json"
+rm -f "${DOCS_BASE_DIR}/metadata.json"
+rm -rf tmp-doc
+
+TARGET_DOCS_DIR='./docs/documentation'
+INDEX_FILE='./docs/index.html'
+BASE_URL='https://walletconnect.github.io/WalletConnectSwiftV2/documentation'
+REPO_NAME='WalletConnectSwiftV2'
+
+target_count=0
+target_list=""
+single_target_name=""
+for target in $(ls "${TARGET_DOCS_DIR}"); do
+    if [ -d "${TARGET_DOCS_DIR}/${target}" ]; then
+        single_target_name="${target}"
+        target_count=$((target_count + 1))
+        target_list="${target_list}<li><a href=\"${BASE_URL}/${target}\"><code>${target}</code> Documentation</a></li>"
+    fi
+done
+if [ ${target_count} -gt 1 ]; then
+    echo "Found ${target_count} targets. Generating list..."
+    cat >"${INDEX_FILE}" <<EOF
+<!DOCTYPE html>
+<html>
+    <head>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #d2d2d2;
+        }
+
+        h1 {
+            text-align: center;
+        }
+
+        ul {
+            list-style-type: none;
+            padding: 0;
+        }
+
+        li {
+            margin-bottom: 10px;
+        }
+
+        a {
+            display: block;
+            padding: 10px;
+            background-color: #ccc;
+            text-decoration: none;
+            color: #337ab7;
+            border-radius: 5px;
+            transition: background-color 0.3s ease;
+        }
+
+        a:hover {
+            background-color: #aaa;
+        }
+    </style>
+        <title>${REPO_NAME} Documentation</title>
+    </head>
+    <body>
+        <h1>${REPO_NAME} Documentation</h1>
+        <ul>
+        ${target_list}
+        </ul>
+    </body>
+</html>
+EOF
+else
+    echo "Found one target. Generating redirect file to target ${single_target_name}"
+    cat >"${INDEX_FILE}" <<EOF
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>${REPO_NAME} Documentation</title>
+        <meta http-equiv="refresh" content="0; url=${BASE_URL}/${single_target_name}" />
+    </head>
+    <body>
+        <p>Redirecting...</p>
+    </body>
+</html>
+EOF
+fi


### PR DESCRIPTION
On push to `main` branch `deploy_pages.yml` workflow is going to be run. Executing the `generate_docs.sh` and then triggers deployment of github pages, deploying static site generated in `docs` directory

generate_docs.sh:

Runs `swift package  generate-documentation` for each target defined in `Package.swift`. Currently there is no support for multiple targets so we are storing produces files in temporary folders and merging these folders in next steps, including generating root `index.html` allowing to navigate to docs for individual targets as seen here 
https://walletconnect.github.io/WalletConnectSwiftV2/

Specific target documentation can be the found on following url
`https://walletconnect.github.io/WalletConnectSwiftV2/documentation/${ TARGET_NAME.allLowerCased }` e.g. `https://walletconnect.github.io/WalletConnectSwiftV2/documentation/walletconnectsign/`
