### PR TITLE
[CI] Use unique cache key for each workflow

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -8,6 +8,9 @@ inputs:
   project-id:
     description: 'WalletConnect project id'
     required: true
+  cache-key:
+    description: 'Cache key to use for caching'
+    required: true
 
 runs:
   using: "composite"
@@ -34,4 +37,4 @@ runs:
       with:
         path: |
           products.tar
-        key: ${{ runner.os }}-deriveddata-${{ github.event.pull_request.head.sha }}
+        key: ${{ runner.os }}-deriveddata-${{ inputs.cache-key }}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: ./.github/actions/build
         with:
           project-id: ${{ secrets.PROJECT_ID }}
+          cache-key: ci
 
   test:
     needs: prepare

--- a/.github/workflows/self_hosted_ci.yml
+++ b/.github/workflows/self_hosted_ci.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: ./.github/actions/build
         with:
           project-id: ${{ secrets.PROJECT_ID }}
+          cache-key: self_hosted_ci
 
   test:
     needs: prepare
@@ -78,7 +79,7 @@ jobs:
       uses: mikepenz/action-junit-report@v3
       if: success() || failure()
       with:
-          check_name: ${{ matrix.type }} junit report
+          check_name: ${{ matrix.type }} self-hosted junit report
           report_paths: 'test_results/report.junit'
 
     - name: Zip test artifacts


### PR DESCRIPTION
Guaranteeing that each pipeline uses the correct cache and no race condition is happening.

This fixes the issue when running two pipelines at the same time and the first which finishes the `prepare` step saves compiled artefacts into a cache, but due to using different archs (ARM/x86) it causes other pipeline to fail. 

It's a temporary solution which will be removed.
