### PR TITLE
Update NotifySubscribeProtocolMethod.swift to match specs

### DIFF
--- a/Sources/WalletConnectNotify/ProtocolMethods/NotifySubscribeProtocolMethod.swift
+++ b/Sources/WalletConnectNotify/ProtocolMethods/NotifySubscribeProtocolMethod.swift
@@ -4,7 +4,7 @@ import Foundation
 struct NotifySubscribeProtocolMethod: ProtocolMethod {
     let method: String = "wc_notifySubscribe"
 
-    let requestConfig: RelayConfig = RelayConfig(tag: 4006, prompt: true, ttl: 86400)
+    let requestConfig: RelayConfig = RelayConfig(tag: 4000, prompt: true, ttl: 86400)
 
-    let responseConfig: RelayConfig = RelayConfig(tag: 4007, prompt: true, ttl: 86400)
+    let responseConfig: RelayConfig = RelayConfig(tag: 4001, prompt: true, ttl: 86400)
 }


### PR DESCRIPTION
# Description
As per the specs here: https://github.com/WalletConnect/walletconnect-docs/blob/main/docs/specs/clients/notify/rpc-methods.md?plain=1

Updating the Tags for Subscribe

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
