### PR TITLE
Set ----> OrderSet

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/WalletConnect-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/WalletConnect-Package.xcscheme
@@ -482,6 +482,76 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WalletConnect_WalletConnectModal"
+               BuildableName = "WalletConnect_WalletConnectModal"
+               BlueprintName = "WalletConnect_WalletConnectModal"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WalletConnectHistory"
+               BuildableName = "WalletConnectHistory"
+               BlueprintName = "WalletConnectHistory"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WalletConnectModal"
+               BuildableName = "WalletConnectModal"
+               BlueprintName = "WalletConnectModal"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WalletConnectSync"
+               BuildableName = "WalletConnectSync"
+               BlueprintName = "WalletConnectSync"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "HTTPClient"
+               BuildableName = "HTTPClient"
+               BlueprintName = "HTTPClient"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
+        }
+      },
+      {
         "package": "SwiftDocCPlugin",
         "repositoryURL": "https://github.com/apple/swift-docc-plugin",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -56,12 +56,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
-        .package(url: "https://github.com/WalletConnect/QRCode", from: "14.3.1")
+        .package(url: "https://github.com/WalletConnect/QRCode", from: "14.3.1"),
+        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.4")),
     ],
     targets: [
         .target(
             name: "WalletConnectSign",
-            dependencies: ["WalletConnectPairing", "WalletConnectVerify"],
+            dependencies: ["WalletConnectPairing", "WalletConnectVerify", .product(name: "OrderedCollections", package: "swift-collections")],
             path: "Sources/WalletConnectSign"),
         .target(
             name: "WalletConnectChat",

--- a/Sources/WalletConnectModal/WalletConnectModal.swift
+++ b/Sources/WalletConnectModal/WalletConnectModal.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OrderedCollections
 import SwiftUI
 
 #if canImport(UIKit)
@@ -146,7 +147,7 @@ public struct SessionParams {
     public static let `default`: Self = {
         let methods: Set<String> = ["eth_sendTransaction", "personal_sign", "eth_signTypedData"]
         let events: Set<String> = ["chainChanged", "accountsChanged"]
-        let blockchains: Set<Blockchain> = [Blockchain("eip155:1")!]
+        let blockchains: OrderedSet<Blockchain> = [Blockchain("eip155:1")!]
         let namespaces: [String: ProposalNamespace] = [
             "eip155": ProposalNamespace(
                 chains: blockchains,

--- a/Sources/WalletConnectSign/Namespace.swift
+++ b/Sources/WalletConnectSign/Namespace.swift
@@ -1,3 +1,5 @@
+import OrderedCollections
+
 public enum AutoNamespacesError: Error {
     case requiredChainsNotSatisfied
     case requiredAccountsNotSatisfied
@@ -7,11 +9,11 @@ public enum AutoNamespacesError: Error {
 
 public struct ProposalNamespace: Equatable, Codable {
 
-    public let chains: Set<Blockchain>?
+    public let chains: OrderedSet<Blockchain>?
     public let methods: Set<String>
     public let events: Set<String>
 
-    public init(chains: Set<Blockchain>? = nil, methods: Set<String>, events: Set<String>) {
+    public init(chains: OrderedSet<Blockchain>? = nil, methods: Set<String>, events: Set<String>) {
         self.chains = chains
         self.methods = methods
         self.events = events
@@ -19,19 +21,19 @@ public struct ProposalNamespace: Equatable, Codable {
 }
 
 public struct SessionNamespace: Equatable, Codable {
-    public var chains: Set<Blockchain>?
-    public var accounts: Set<Account>
+    public var chains: OrderedSet<Blockchain>?
+    public var accounts: OrderedSet<Account>
     public var methods: Set<String>
     public var events: Set<String>
 
-    public init(chains: Set<Blockchain>? = nil, accounts: Set<Account>, methods: Set<String>, events: Set<String>) {
+    public init(chains: OrderedSet<Blockchain>? = nil, accounts: OrderedSet<Account>, methods: Set<String>, events: Set<String>) {
         self.chains = chains
         self.accounts = accounts
         self.methods = methods
         self.events = events
     }
 
-    static func accountsAreCompliant(_ accounts: Set<Account>, toChains chains: Set<Blockchain>) -> Bool {
+    static func accountsAreCompliant(_ accounts: OrderedSet<Account>, toChains chains: OrderedSet<Blockchain>) -> Bool {
         for chain in chains {
             guard accounts.contains(where: { $0.blockchain == chain }) else {
                 return false
@@ -186,8 +188,8 @@ public enum AutoNamespaces {
                 }
 
                 let sessionNamespace = SessionNamespace(
-                    chains: sessionChains,
-                    accounts: Set(accounts).filter { sessionChains.contains($0.blockchain) },
+                    chains: OrderedSet(sessionChains),
+                    accounts: OrderedSet(accounts.filter { sessionChains.contains($0.blockchain) }),
                     methods: sessionMethods,
                     events: sessionEvents
                 )
@@ -229,8 +231,8 @@ public enum AutoNamespaces {
                     }
 
                     let sessionNamespace = SessionNamespace(
-                        chains: Set([Blockchain(namespace: network, reference: chain)!]),
-                        accounts: Set(accounts).filter { $0.blockchain == Blockchain(namespace: network, reference: chain)! },
+                        chains: OrderedSet([Blockchain(namespace: network, reference: chain)!]),
+                        accounts: OrderedSet(accounts.filter { $0.blockchain == Blockchain(namespace: network, reference: chain)! }),
                         methods: sessionMethods,
                         events: sessionEvents
                     )
@@ -269,8 +271,8 @@ public enum AutoNamespaces {
                 let sessionEvents = Set(proposalNamespace.events).intersection(Set(events))
 
                 let sessionNamespace = SessionNamespace(
-                    chains: sessionChains,
-                    accounts: Set(accounts).filter { sessionChains.contains($0.blockchain) },
+                    chains: OrderedSet(sessionChains),
+                    accounts: OrderedSet(accounts.filter { sessionChains.contains($0.blockchain) }),
                     methods: sessionMethods,
                     events: sessionEvents
                 )
@@ -304,8 +306,8 @@ public enum AutoNamespaces {
                     let sessionEvents = Set(proposalNamespace.events).intersection(Set(events))
                     
                     let sessionNamespace = SessionNamespace(
-                        chains: Set([Blockchain(namespace: network, reference: chain)!]),
-                        accounts: Set(accounts).filter { $0.blockchain == Blockchain(namespace: network, reference: chain)! },
+                        chains: OrderedSet([Blockchain(namespace: network, reference: chain)!]),
+                        accounts: OrderedSet(accounts.filter { $0.blockchain == Blockchain(namespace: network, reference: chain)! }),
                         methods: sessionMethods,
                         events: sessionEvents
                     )

--- a/Tests/WalletConnectSignTests/AutoNamespacesValidationTests.swift
+++ b/Tests/WalletConnectSignTests/AutoNamespacesValidationTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WalletConnectSign
+@testable import OrderedCollections
 
 final class AutoNamespacesValidationTests: XCTestCase {
     func testAutoNamespacesSameChainRequiredAndOptional() async {
@@ -37,7 +38,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!],
-                accounts: Set(accounts),
+                accounts: OrderedSet(accounts),
                 methods: ["personal_sign", "eth_sendTransaction"],
                 events: ["chainChanged"]
             )
@@ -84,7 +85,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!, Blockchain("eip155:2")!],
-                accounts: Set(accounts),
+                accounts: OrderedSet(accounts),
                 methods: ["personal_sign", "eth_sendTransaction"],
                 events: ["chainChanged"]
             )
@@ -129,7 +130,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!, Blockchain("eip155:2")!],
-                accounts: Set(accounts),
+                accounts: OrderedSet(accounts),
                 methods: ["personal_sign", "eth_sendTransaction"],
                 events: ["chainChanged"]
             )
@@ -179,7 +180,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!, Blockchain("eip155:2")!, Blockchain("eip155:3")!],
-                accounts: Set(accounts),
+                accounts: OrderedSet(accounts),
                 methods: ["personal_sign", "eth_sendTransaction"],
                 events: ["chainChanged"]
             )
@@ -234,7 +235,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!, Blockchain("eip155:2")!, Blockchain("eip155:3")!, Blockchain("eip155:4")!],
-                accounts: Set(accounts),
+                accounts: OrderedSet(accounts),
                 methods: ["personal_sign", "eth_sendTransaction"],
                 events: ["chainChanged"]
             )
@@ -287,7 +288,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!, Blockchain("eip155:2")!],
-                accounts: Set(accounts),
+                accounts: OrderedSet(accounts),
                 methods: ["personal_sign", "eth_sendTransaction"],
                 events: ["chainChanged"]
             )
@@ -341,7 +342,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!, Blockchain("eip155:2")!, Blockchain("eip155:4")!],
-                accounts: Set(accounts),
+                accounts: OrderedSet(accounts),
                 methods: ["personal_sign", "eth_sendTransaction"],
                 events: ["chainChanged"]
             )
@@ -390,7 +391,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!, Blockchain("eip155:2")!],
-                accounts: Set(accounts),
+                accounts: OrderedSet(accounts),
                 methods: ["personal_sign", "eth_sendTransaction", "eth_signTransaction"],
                 events: ["chainChanged"]
             )
@@ -439,7 +440,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!, Blockchain("eip155:2")!],
-                accounts: Set(accounts),
+                accounts: OrderedSet(accounts),
                 methods: ["personal_sign", "eth_sendTransaction", "eth_signTransaction"],
                 events: ["chainChanged", "accountsChanged"]
             )
@@ -544,7 +545,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!, Blockchain("eip155:2")!],
-                accounts: Set([
+                accounts: OrderedSet([
                     Account(blockchain: Blockchain("eip155:1")!, address: "0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092")!,
                     Account(blockchain: Blockchain("eip155:2")!, address: "0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092")!
                 ]),
@@ -836,7 +837,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!],
-                accounts: Set([
+                accounts: OrderedSet([
                     Account(blockchain: Blockchain("eip155:1")!, address: "0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092")!
                 ]),
                 methods: ["eth_signTypedData_v4", "eth_signTransaction", "eth_signTypedData", "eth_sign", "personal_sign", "eth_sendTransaction"],
@@ -883,7 +884,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!],
-                accounts: Set([
+                accounts: OrderedSet([
                     Account(blockchain: Blockchain("eip155:1")!, address: "0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092")!
                 ]),
                 methods: ["eth_signTypedData_v4", "eth_signTransaction", "eth_signTypedData", "eth_sign", "personal_sign", "eth_sendTransaction"],
@@ -930,7 +931,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!],
-                accounts: Set([
+                accounts: OrderedSet([
                     Account(blockchain: Blockchain("eip155:1")!, address: "0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092")!
                 ]),
                 methods: ["eth_signTypedData_v4", "eth_signTransaction", "eth_signTypedData", "eth_sign", "personal_sign", "eth_sendTransaction"],
@@ -982,7 +983,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
         let expectedNamespaces: [String: SessionNamespace] = [
             "eip155": SessionNamespace(
                 chains: [Blockchain("eip155:1")!],
-                accounts: Set([
+                accounts: OrderedSet([
                     Account(blockchain: Blockchain("eip155:1")!, address: "0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092")!
                 ]),
                 methods: ["eth_signTypedData_v4", "eth_signTransaction", "eth_signTypedData", "eth_sign", "personal_sign", "eth_sendTransaction"],
@@ -990,7 +991,7 @@ final class AutoNamespacesValidationTests: XCTestCase {
             ),
             "solana": SessionNamespace(
                 chains: [Blockchain("solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ")!],
-                accounts: Set([
+                accounts: OrderedSet([
                     Account(blockchain: Blockchain("solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ")!, address: "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ")!,
                 ]),
                 methods: ["solana_signMessage"],


### PR DESCRIPTION
Wallets sometimes encounter a situation where authorizations do not receive a response when interacting with certain dApps. Upon investigation, it has been found that dApps retrieve the first element from the authorization array, and using a Set can alter the order of authorizations. The recommended approach is to use an OrderSet, which not only removes duplicates but also maintains the original order of authorizations.