### PR TITLE
[Verify] Update verify UI

### DIFF
--- a/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa.git",
         "state": {
           "branch": null,
-          "revision": "04bee4ad86d74d4cb4d7101ff826d6e355301ba9",
-          "version": "8.9.4"
+          "revision": "12998398eb51e2e8ff7098163fa97d305eee6d87",
+          "version": "8.11.0"
         }
       },
       {

--- a/Example/WalletApp/PresentationLayer/Wallet/AuthRequest/AuthRequestView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/AuthRequest/AuthRequestView.swift
@@ -26,19 +26,30 @@ struct AuthRequestView: View {
                         .foregroundColor(.grey8)
                         .font(.system(size: 22, weight: .medium, design: .rounded))
                     
-                    Text(presenter.request.payload.domain)
-                        .foregroundColor(.grey50)
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .multilineTextAlignment(.center)
-                        .lineSpacing(4)
+                    if case .valid = presenter.validationStatus {
+                        HStack {
+                            Image(systemName: "checkmark.seal.fill")
+                                .font(.system(size: 14, weight: .semibold, design: .rounded))
+                                .foregroundColor(.blue)
+                            
+                            Text(presenter.request.payload.domain)
+                                .foregroundColor(.grey8)
+                                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                                .lineSpacing(4)
+                        }
                         .padding(.top, 8)
+                    } else {
+                        Text(presenter.request.payload.domain)
+                            .foregroundColor(.grey8)
+                            .font(.system(size: 13, weight: .semibold, design: .rounded))
+                            .multilineTextAlignment(.center)
+                            .lineSpacing(4)
+                            .padding(.top, 8)
+                    }
                     
                     switch presenter.validationStatus {
                     case .unknown:
                         verifyBadgeView(imageName: "exclamationmark.circle.fill", title: "Cannot verify", color: .orange)
-                        
-                    case .valid:
-                        verifyBadgeView(imageName: "checkmark.seal.fill", title: "Verified domain", color: .blue)
                         
                     case .invalid:
                         verifyBadgeView(imageName: "exclamationmark.triangle.fill", title: "Invalid domain", color: .red)
@@ -68,52 +79,21 @@ struct AuthRequestView: View {
                         }
                     }
                     
-                    HStack(spacing: 20) {
-                        Button {
-                            Task(priority: .userInitiated) { try await
-                                presenter.onReject()
-                            }
-                        } label: {
-                            Text("Decline")
-                                .frame(maxWidth: .infinity)
-                                .foregroundColor(.white)
-                                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                .padding(.vertical, 11)
-                                .background(
-                                    LinearGradient(
-                                        gradient: Gradient(colors: [
-                                            .foregroundNegative,
-                                            .lightForegroundNegative
-                                        ]),
-                                        startPoint: .top, endPoint: .bottom)
-                                )
-                                .cornerRadius(20)
+                    if case .scam = presenter.validationStatus {
+                        VStack(spacing: 20) {
+                            declineButton()
+                            allowButton()
                         }
-                        .shadow(color: .white.opacity(0.25), radius: 8, y: 2)
-                        
-                        Button {
-                            Task(priority: .userInitiated) { try await
-                                presenter.onApprove()
-                            }
-                        } label: {
-                            Text("Allow")
-                                .frame(maxWidth: .infinity)
-                                .foregroundColor(.white)
-                                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                .padding(.vertical, 11)
-                                .background(
-                                    LinearGradient(
-                                        gradient: Gradient(colors: [
-                                            .foregroundPositive,
-                                            .lightForegroundPositive
-                                        ]),
-                                        startPoint: .top, endPoint: .bottom)
-                                )
-                                .cornerRadius(20)
+                        .padding(.top, 25)
+                    } else {
+                        HStack {
+                            declineButton()
+                            allowButton()
                         }
-                        .shadow(color: .white.opacity(0.25), radius: 8, y: 2)
+                        .padding(.top, 25)
                     }
-                    .padding(.top, 25)
+                    
+                    
                 }
                 .padding(20)
                 .background(.ultraThinMaterial)
@@ -147,13 +127,12 @@ struct AuthRequestView: View {
                     }
                     .padding(.horizontal, 18)
                     .padding(.vertical, 10)
-                    .frame(height: 250)
+                    .frame(height: 150)
                 }
                 .background(Color.whiteBackground)
                 .cornerRadius(20, corners: .allCorners)
                 .padding(.horizontal, 5)
                 .padding(.bottom, 5)
-
             }
             .background(.thinMaterial)
             .cornerRadius(25, corners: .allCorners)
@@ -198,6 +177,61 @@ struct AuthRequestView: View {
         .padding()
         .background(color.opacity(0.15))
         .cornerRadius(20)
+    }
+    
+    private func declineButton() -> some View {
+        Button {
+            Task(priority: .userInitiated) { try await
+                presenter.onReject()
+            }
+        } label: {
+            Text("Decline")
+                .frame(maxWidth: .infinity)
+                .foregroundColor(.white)
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .padding(.vertical, 11)
+                .background(
+                    LinearGradient(
+                        gradient: Gradient(colors: [
+                            .foregroundNegative,
+                            .lightForegroundNegative
+                        ]),
+                        startPoint: .top, endPoint: .bottom)
+                )
+                .cornerRadius(20)
+        }
+        .shadow(color: .white.opacity(0.25), radius: 8, y: 2)
+    }
+    
+    private func allowButton() -> some View {
+        Button {
+            Task(priority: .userInitiated) { try await
+                presenter.onApprove()
+            }
+        } label: {
+            Text(presenter.validationStatus == .scam ? "Proceed anyway" : "Allow")
+                .frame(maxWidth: .infinity)
+                .foregroundColor(presenter.validationStatus == .scam ? .grey50 : .white)
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .padding(.vertical, 11)
+                .background(
+                    Group {
+                        if presenter.validationStatus == .scam {
+                            Color.clear
+                        } else {
+                            LinearGradient(
+                                gradient: Gradient(colors: [
+                                    .foregroundPositive,
+                                    .lightForegroundPositive
+                                ]),
+                                startPoint: .top, endPoint: .bottom
+                            )
+                        }
+                    }
+                )
+                .cornerRadius(20)
+        }
+        .shadow(color: .white.opacity(0.25), radius: 8, y: 2)
     }
 }
 

--- a/Example/WalletApp/PresentationLayer/Wallet/SessionProposal/SessionProposalView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/SessionProposal/SessionProposalView.swift
@@ -30,19 +30,30 @@ struct SessionProposalView: View {
                         .foregroundColor(.grey8)
                         .font(.system(size: 22, weight: .medium, design: .rounded))
                     
-                    Text(presenter.sessionProposal.proposer.url)
-                        .foregroundColor(.grey50)
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .multilineTextAlignment(.center)
-                        .lineSpacing(4)
+                    if case .valid = presenter.validationStatus {
+                        HStack {
+                            Image(systemName: "checkmark.seal.fill")
+                                .font(.system(size: 14, weight: .semibold, design: .rounded))
+                                .foregroundColor(.blue)
+                            
+                            Text(presenter.sessionProposal.proposer.url)
+                                .foregroundColor(.grey8)
+                                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                                .lineSpacing(4)
+                        }
                         .padding(.top, 8)
+                    } else {
+                        Text(presenter.sessionProposal.proposer.url)
+                            .foregroundColor(.grey8)
+                            .font(.system(size: 13, weight: .semibold, design: .rounded))
+                            .multilineTextAlignment(.center)
+                            .lineSpacing(4)
+                            .padding(.top, 8)
+                    }
                     
                     switch presenter.validationStatus {
                     case .unknown:
                         verifyBadgeView(imageName: "exclamationmark.circle.fill", title: "Cannot verify", color: .orange)
-                        
-                    case .valid:
-                        verifyBadgeView(imageName: "checkmark.seal.fill", title: "Verified domain", color: .blue)
                         
                     case .invalid:
                         verifyBadgeView(imageName: "exclamationmark.triangle.fill", title: "Invalid domain", color: .red)
@@ -89,7 +100,7 @@ struct SessionProposalView: View {
                             }
                         }
                     }
-                    .frame(height: 250)
+                    .frame(height: 150)
                     .cornerRadius(20)
                     .padding(.vertical, 12)
                     
@@ -107,52 +118,19 @@ struct SessionProposalView: View {
                         EmptyView()
                     }
                     
-                    HStack(spacing: 20) {
-                        Button {
-                            Task(priority: .userInitiated) { try await
-                                presenter.onReject()
-                            }
-                        } label: {
-                            Text("Decline")
-                                .frame(maxWidth: .infinity)
-                                .foregroundColor(.white)
-                                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                .padding(.vertical, 11)
-                                .background(
-                                    LinearGradient(
-                                        gradient: Gradient(colors: [
-                                            .foregroundNegative,
-                                            .lightForegroundNegative
-                                        ]),
-                                        startPoint: .top, endPoint: .bottom)
-                                )
-                                .cornerRadius(20)
+                    if case .scam = presenter.validationStatus {
+                        VStack(spacing: 20) {
+                            declineButton()
+                            allowButton()
                         }
-                        .shadow(color: .white.opacity(0.25), radius: 8, y: 2)
-                        
-                        Button {
-                            Task(priority: .userInitiated) { try await
-                                presenter.onApprove()
-                            }
-                        } label: {
-                            Text("Allow")
-                                .frame(maxWidth: .infinity)
-                                .foregroundColor(.white)
-                                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                .padding(.vertical, 11)
-                                .background(
-                                    LinearGradient(
-                                        gradient: Gradient(colors: [
-                                            .foregroundPositive,
-                                            .lightForegroundPositive
-                                        ]),
-                                        startPoint: .top, endPoint: .bottom)
-                                )
-                                .cornerRadius(20)
+                        .padding(.top, 25)
+                    } else {
+                        HStack {
+                            declineButton()
+                            allowButton()
                         }
-                        .shadow(color: .white.opacity(0.25), radius: 8, y: 2)
+                        .padding(.top, 25)
                     }
-                    .padding(.top, 25)
                 }
                 .padding(20)
                 .background(.ultraThinMaterial)
@@ -283,6 +261,61 @@ struct SessionProposalView: View {
         .padding()
         .background(color.opacity(0.15))
         .cornerRadius(20)
+    }
+    
+    private func declineButton() -> some View {
+        Button {
+            Task(priority: .userInitiated) { try await
+                presenter.onReject()
+            }
+        } label: {
+            Text("Decline")
+                .frame(maxWidth: .infinity)
+                .foregroundColor(.white)
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .padding(.vertical, 11)
+                .background(
+                    LinearGradient(
+                        gradient: Gradient(colors: [
+                            .foregroundNegative,
+                            .lightForegroundNegative
+                        ]),
+                        startPoint: .top, endPoint: .bottom)
+                )
+                .cornerRadius(20)
+        }
+        .shadow(color: .white.opacity(0.25), radius: 8, y: 2)
+    }
+    
+    private func allowButton() -> some View {
+        Button {
+            Task(priority: .userInitiated) { try await
+                presenter.onApprove()
+            }
+        } label: {
+            Text(presenter.validationStatus == .scam ? "Proceed anyway" : "Allow")
+                .frame(maxWidth: .infinity)
+                .foregroundColor(presenter.validationStatus == .scam ? .grey50 : .white)
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .padding(.vertical, 11)
+                .background(
+                    Group {
+                        if presenter.validationStatus == .scam {
+                            Color.clear
+                        } else {
+                            LinearGradient(
+                                gradient: Gradient(colors: [
+                                    .foregroundPositive,
+                                    .lightForegroundPositive
+                                ]),
+                                startPoint: .top, endPoint: .bottom
+                            )
+                        }
+                    }
+                )
+                .cornerRadius(20)
+        }
+        .shadow(color: .white.opacity(0.25), radius: 8, y: 2)
     }
 }
 

--- a/Example/WalletApp/PresentationLayer/Wallet/SessionRequest/SessionRequestInteractor.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/SessionRequest/SessionRequestInteractor.swift
@@ -22,4 +22,8 @@ final class SessionRequestInteractor {
             response: .error(.init(code: 0, message: ""))
         )
     }
+    
+    func getSession(topic: String) -> Session? {
+        return Web3Wallet.instance.getSessions().first(where: { $0.topic == topic })
+    }
 }

--- a/Example/WalletApp/PresentationLayer/Wallet/SessionRequest/SessionRequestPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/SessionRequest/SessionRequestPresenter.swift
@@ -9,6 +9,7 @@ final class SessionRequestPresenter: ObservableObject {
     private let importAccount: ImportAccount
     
     let sessionRequest: Request
+    let session: Session?
     let validationStatus: VerifyContext.ValidationStatus?
     
     var message: String {
@@ -31,6 +32,7 @@ final class SessionRequestPresenter: ObservableObject {
         self.interactor = interactor
         self.router = router
         self.sessionRequest = sessionRequest
+        self.session = interactor.getSession(topic: sessionRequest.topic)
         self.importAccount = importAccount
         self.validationStatus = context?.validation
     }


### PR DESCRIPTION
# Description

- For `valid` status only badge should be displayed
- For `scam` status we wanna push users to reject

<img src="https://github.com/WalletConnect/WalletConnectSwiftV2/assets/15164826/656ddba4-2679-48fb-96d9-14ff01513940" width=200>
<img src="https://github.com/WalletConnect/WalletConnectSwiftV2/assets/15164826/1629004c-0bbe-4a23-9f56-deba9f3e5efb" width=200>
<img src="https://github.com/WalletConnect/WalletConnectSwiftV2/assets/15164826/c9b11051-6a66-4f4f-a27b-430b3fa20266" width=200>


## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
