### PR TITLE
Store uri into Session

### DIFF
--- a/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/ApproveEngine.swift
@@ -156,6 +156,7 @@ final class ApproveEngine {
         let session = WCSession(
             topic: topic,
             pairingTopic: pairingTopic,
+            symKey: agreementKeys.sharedKey.hexRepresentation,
             timestamp: Date(),
             selfParticipant: selfParticipant,
             peerParticipant: proposal.proposer,
@@ -371,6 +372,7 @@ private extension ApproveEngine {
         let session = WCSession(
             topic: sessionTopic,
             pairingTopic: pairingTopic,
+            symKey: agreementKeys.sharedKey.hexRepresentation,
             timestamp: Date(),
             selfParticipant: selfParticipant,
             peerParticipant: params.controller,

--- a/Sources/WalletConnectSign/Session.swift
+++ b/Sources/WalletConnectSign/Session.swift
@@ -6,6 +6,8 @@ import Foundation
 public struct Session: Codable {
     public let topic: String
     public let pairingTopic: String
+    public let symKey: String
+    public let relay: RelayProtocolOptions
     public let peer: AppMetadata
     public let requiredNamespaces: [String: ProposalNamespace]
     public let namespaces: [String: SessionNamespace]
@@ -66,5 +68,11 @@ extension Session {
         return namespaces.values.reduce(into: []) { result, namespace in
             result = result + Array(namespace.accounts)
         }
+    }
+
+    public var uri: WalletConnectURI {
+        return WalletConnectURI(topic: pairingTopic,
+                                symKey: symKey,
+                                relay: relay)
     }
 }

--- a/Sources/WalletConnectSign/Types/Session/WCSession.swift
+++ b/Sources/WalletConnectSign/Types/Session/WCSession.swift
@@ -8,6 +8,7 @@ struct WCSession: SequenceObject, Equatable {
 
     let topic: String
     let pairingTopic: String
+    let symKey: String
     let relay: RelayProtocolOptions
     let selfParticipant: Participant
     let peerParticipant: Participant
@@ -30,6 +31,7 @@ struct WCSession: SequenceObject, Equatable {
 
     init(topic: String,
          pairingTopic: String,
+         symKey: String,
          timestamp: Date,
          selfParticipant: Participant,
          peerParticipant: Participant,
@@ -38,6 +40,7 @@ struct WCSession: SequenceObject, Equatable {
          acknowledged: Bool) {
         self.topic = topic
         self.pairingTopic = pairingTopic
+        self.symKey = symKey
         self.timestamp = timestamp
         self.relay = settleParams.relay
         self.controller = AgreementPeer(publicKey: settleParams.controller.publicKey)
@@ -54,6 +57,7 @@ struct WCSession: SequenceObject, Equatable {
     internal init(
         topic: String,
         pairingTopic: String,
+        symKey: String,
         timestamp: Date,
         relay: RelayProtocolOptions,
         controller: AgreementPeer,
@@ -69,6 +73,7 @@ struct WCSession: SequenceObject, Equatable {
     ) {
         self.topic = topic
         self.pairingTopic = pairingTopic
+        self.symKey = symKey
         self.timestamp = timestamp
         self.relay = relay
         self.controller = controller
@@ -168,6 +173,8 @@ struct WCSession: SequenceObject, Equatable {
         return Session(
             topic: topic,
             pairingTopic: pairingTopic,
+            symKey: symKey,
+            relay: relay,
             peer: peerParticipant.metadata,
             requiredNamespaces: requiredNamespaces,
             namespaces: namespaces,
@@ -182,7 +189,7 @@ struct WCSession: SequenceObject, Equatable {
 extension WCSession {
 
     enum CodingKeys: String, CodingKey {
-        case topic, pairingTopic, relay, selfParticipant, peerParticipant, expiryDate, acknowledged, controller, namespaces, timestamp, requiredNamespaces, sessionProperties
+        case topic, pairingTopic, symKey, relay, selfParticipant, peerParticipant, expiryDate, acknowledged, controller, namespaces, timestamp, requiredNamespaces, sessionProperties
     }
 
     init(from decoder: Decoder) throws {
@@ -199,6 +206,7 @@ extension WCSession {
         self.timestamp = try container.decode(Date.self, forKey: .timestamp)
         self.requiredNamespaces = try container.decode([String: ProposalNamespace].self, forKey: .requiredNamespaces)
         self.pairingTopic = try container.decode(String.self, forKey: .pairingTopic)
+        self.symKey = try container.decode(String.self, forKey: .symKey)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -215,5 +223,6 @@ extension WCSession {
         try container.encode(expiryDate, forKey: .expiryDate)
         try container.encode(timestamp, forKey: .timestamp)
         try container.encode(requiredNamespaces, forKey: .requiredNamespaces)
+        try container.encode(symKey, forKey: .symKey)
     }
 }

--- a/Tests/WalletConnectSignTests/Stub/Session+Stub.swift
+++ b/Tests/WalletConnectSignTests/Stub/Session+Stub.swift
@@ -15,11 +15,13 @@ extension WCSession {
         timestamp: Date = Date()
     ) -> WCSession {
             let peerKey = selfPrivateKey.publicKey.hexRepresentation
+            let symKey = AgreementPrivateKey().publicKey.hexRepresentation
             let selfKey = AgreementPrivateKey().publicKey.hexRepresentation
             let controllerKey = isSelfController ? selfKey : peerKey
             return WCSession(
                 topic: topic,
                 pairingTopic: "",
+                symKey: symKey,
                 timestamp: timestamp,
                 relay: RelayProtocolOptions.stub(),
                 controller: AgreementPeer(publicKey: controllerKey),


### PR DESCRIPTION
# Description

Added `wcUri` into the Session for later use. 
Was supported in WalletConnect V1. 
Makes is easy to migrate from WalletConnect V1 from V2 for dApps, especially when dApps have to support both.