### PR TITLE
[Sign] Expose session event publisher

### DIFF
--- a/Sources/WalletConnectSign/Sign/SignClientProtocol.swift
+++ b/Sources/WalletConnectSign/Sign/SignClientProtocol.swift
@@ -10,6 +10,7 @@ public protocol SignClientProtocol {
     var sessionDeletePublisher: AnyPublisher<(String, Reason), Never> { get }
     var sessionResponsePublisher: AnyPublisher<Response, Never> { get }
     var sessionRejectionPublisher: AnyPublisher<(Session.Proposal, Reason), Never> { get }
+    var sessionEventPublisher: AnyPublisher<(event: Session.Event, sessionTopic: String, chainId: Blockchain?), Never> { get }
     
     func connect(requiredNamespaces: [String: ProposalNamespace], optionalNamespaces: [String: ProposalNamespace]?, sessionProperties: [String: String]?, topic: String) async throws
     func request(params: Request) async throws

--- a/Tests/Web3WalletTests/Mocks/SignClientMock.swift
+++ b/Tests/Web3WalletTests/Mocks/SignClientMock.swift
@@ -59,6 +59,17 @@ final class SignClientMock: SignClientProtocol {
             .eraseToAnyPublisher()
     }
     
+    var sessionEventPublisher: AnyPublisher<(event: WalletConnectSign.Session.Event, sessionTopic: String, chainId: WalletConnectUtils.Blockchain?), Never> {
+        return Result.Publisher(
+            (
+                WalletConnectSign.Session.Event(name: "chainChanged", data: AnyCodable("event_data")),
+                "topic",
+                Blockchain("eip155:1")
+            )
+        )
+            .eraseToAnyPublisher()
+    }
+    
     var sessionRejectionPublisher: AnyPublisher<(Session.Proposal, Reason), Never> {
         let sessionProposal = Session.Proposal(
             id: "",


### PR DESCRIPTION
Web3Modal needs to listen for the "chainChanged" event so that it can reflect the chain switch accordingly.