### PR TITLE
Update WalletPairService.swift

### DIFF
--- a/Sources/WalletConnectPairing/Services/Wallet/WalletPairService.swift
+++ b/Sources/WalletConnectPairing/Services/Wallet/WalletPairService.swift
@@ -4,6 +4,7 @@ actor WalletPairService {
     enum Errors: Error {
         case pairingAlreadyExist(topic: String)
         case networkNotConnected
+        case noPendingRequest
     }
 
     let networkingInteractor: NetworkInteracting
@@ -30,7 +31,7 @@ actor WalletPairService {
         logger.debug("Pairing with uri: \(uri)")
         guard try !pairingHasPendingRequest(for: uri.topic) else {
             logger.debug("Pairing with topic (\(uri.topic)) has pending request")
-            return
+            throw Errors.noPendingRequest
         }
         
         let pairing = WCPairing(uri: uri)


### PR DESCRIPTION
Since the method is marked as `throws`, when called within a `do` block, nothing happens if the session is already inactive, consequently making it impossible to handle.
