### PR TITLE
Remove sample release cron job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: release
 
 on:
-  schedule:
-    # Runs "Every Monday 10am CET"
-    - cron: '0 10 * * 1'
-
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Description
Removed the cron job that releases wallet and showcase sample every Monday
* This will allow for only releasing samples once 

Resolves # (issue)

## How Has This Been Tested?


## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
