### PR TITLE
Add option to specify what app to release

### DIFF
--- a/.env.DApp
+++ b/.env.DApp
@@ -1,0 +1,4 @@
+SCHEME = "DApp" 
+APP_IDENTIFIER = "com.walletconnect.dapp" 
+MATCH_IDENTIFIERS = "com.walletconnect.dapp"
+APPLE_ID = "1606875879"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,14 @@ name: release
 
 on:
   workflow_dispatch:
+    inputs:
+      app:
+        type: choice
+        description: Which sample app to release
+        options: 
+        - DApp
+        - WalletApp
+        - Showcase
 
 jobs:
   build:
@@ -32,4 +40,4 @@ jobs:
         APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
         WALLETAPP_SENTRY_DSN: ${{ secrets.WALLETAPP_SENTRY_DSN }}
       run: |
-        make release_wallet APPLE_ID=${{ secrets.APPLE_ID }} TOKEN=$(echo -n $GH_USER:$GH_TOKEN | base64) PROJECT_ID=${{ secrets.RELEASE_PROJECT_ID }} WALLETAPP_SENTRY_DSN=${{ secrets.WALLETAPP_SENTRY_DSN }} MIXPANEL_TOKEN=${{secrets.MIXPANEL_TOKEN}}
+        make release APPLE_ID=${{ secrets.APPLE_ID }} TOKEN=$(echo -n $GH_USER:$GH_TOKEN | base64) PROJECT_ID=${{ secrets.RELEASE_PROJECT_ID }} WALLETAPP_SENTRY_DSN=${{ secrets.WALLETAPP_SENTRY_DSN }} MIXPANEL_TOKEN=${{secrets.MIXPANEL_TOKEN}} APP=${{ github.event.inputs.app }}

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,5 @@ smoke_tests:
 x_platform_protocol_tests:
 	./run_tests.sh --scheme IntegrationTests --testplan XPlatformProtocolTests --project Example/ExampleApp.xcodeproj
 
-release_wallet:
-	fastlane release_testflight username:$(APPLE_ID) token:$(TOKEN) relay_host:$(RELAY_HOST) project_id:$(PROJECT_ID) sentry_dsn:$(WALLETAPP_SENTRY_DSN) mixpanel_token:$(MIXPANEL_TOKEN) --env WalletApp
-
-release_showcase:
-	fastlane release_testflight username:$(APPLE_ID) token:$(TOKEN) relay_host:$(RELAY_HOST) project_id:$(PROJECT_ID) --env Showcase
-
-release_all:
-	fastlane release_testflight username:$(APPLE_ID) token:$(TOKEN) relay_host:$(RELAY_HOST) project_id:$(PROJECT_ID) sentry_dsn:$(WALLETAPP_SENTRY_DSN) mixpanel_token:$(MIXPANEL_TOKEN) --env WalletApp
-	fastlane release_testflight username:$(APPLE_ID) token:$(TOKEN) relay_host:$(RELAY_HOST) project_id:$(PROJECT_ID) --env Showcase
+release:
+	fastlane release_testflight username:$(APPLE_ID) token:$(TOKEN) relay_host:$(RELAY_HOST) project_id:$(PROJECT_ID) sentry_dsn:$(WALLETAPP_SENTRY_DSN) mixpanel_token:$(MIXPANEL_TOKEN) --env $(APP)


### PR DESCRIPTION
Can be tested with this CLI command 

`gh workflow run release --ref feat/release_app_option -f app=DApp`