### PR TITLE
replaced all instances of M1 runners with Github M1 runners

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -16,8 +16,7 @@ on:
 
 jobs:
   build:    
-    runs-on: 
-      group: apple-silicon
+    runs-on: macos-latest-xlarge
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,8 +13,7 @@ env:
   PACKAGE_VERSION: ${{ github.event.pull_request.title }}
 jobs:
   set-user-agent:
-    runs-on: 
-      group: apple-silicon
+    runs-on: macos-latest-xlarge
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
 
   prepare:
     needs: authorize
-    runs-on: 
-      group: apple-silicon
+    runs-on: macos-latest-xlarge
     steps:
       - uses: actions/checkout@v3
         with:
@@ -36,8 +35,7 @@ jobs:
 
   test:
     needs: prepare
-    runs-on: 
-      group: apple-silicon
+    runs-on: macos-latest-xlarge
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -5,8 +5,7 @@ on:
     types: [ published ]
 jobs:
   set-user-agent:
-    runs-on: 
-      group: apple-silicon
+    runs-on: macos-latest-xlarge
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -27,8 +27,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: 
-      group: apple-silicon
+    runs-on: macos-latest-xlarge
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: 
-      group: apple-silicon
+    runs-on: macos-latest-xlarge
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
# Description
* Changed M1 runner to move away from Scaleway

## How Has This Been Tested?
* Validated solution works on rs-relay pipeline

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
