### PR TITLE
Update Cacao.swift

### DIFF
--- a/Sources/WalletConnectUtils/Cacao/Cacao.swift
+++ b/Sources/WalletConnectUtils/Cacao/Cacao.swift
@@ -36,7 +36,7 @@ extension Cacao {
             resources: resources
         )
         let signature = CacaoSignature(
-            t: WalletConnectUtils.CacaoSignatureType.eip191,
+            t: CacaoSignatureType.eip191,
             s: "invalid_signature",
             m: nil
         )


### PR DESCRIPTION
Fix error when import SDK from cocoapods.

# Description

When import 1.8.4 with cocoapods, meet error `Cannot find 'WalletConnectUtils' in scope`

