### PR TITLE
Fix import issue with WalletConnectUtils

### DIFF
--- a/Sources/WalletConnectUtils/Cacao/Cacao.swift
+++ b/Sources/WalletConnectUtils/Cacao/Cacao.swift
@@ -36,7 +36,7 @@ extension Cacao {
             resources: resources
         )
         let signature = CacaoSignature(
-            t: WalletConnectUtils.CacaoSignatureType.eip191,
+            t: CacaoSignatureType.eip191,
             s: "invalid_signature",
             m: nil
         )


### PR DESCRIPTION
Thank you for considering this change, and please let me know if there's any additional context I can provide. I have not tested this using SPM, and wonder if there may be some conflicts with that installation method. Perhaps we can wrap this in some additional flags to make it only available for SPM, if that's the case?

It's worth noting this issue is blocking installation of the more recent versions of this library via cocoapods. 

# Description

The following compilation error occurs when installed via cocoapods with DEBUG enabled.

```
  37 |         )
  38 |         let signature = CacaoSignature(
> 39 |             t: WalletConnectUtils.CacaoSignatureType.eip191,
     |                ^ cannot find 'WalletConnectUtils' in scope
  40 |             s: "invalid_signature",
  41 |             m: nil
  42 |         )
```


Related: https://github.com/WalletConnect/WalletConnectSwiftV2/pull/1340


## How Has This Been Tested?

Run a local install + build.

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
