### PR TITLE
Clear related pending requests on session disconnect

### DIFF
--- a/Sources/WalletConnectSign/Engine/Common/DeleteSessionService.swift
+++ b/Sources/WalletConnectSign/Engine/Common/DeleteSessionService.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-class DeleteSessionService {
+protocol DeleteSessionServiceProtocol {
+    
+    func delete(topic: String) async throws
+}
+
+final class DeleteSessionService: DeleteSessionServiceProtocol {
     private let networkingInteractor: NetworkInteracting
     private let kms: KeyManagementServiceProtocol
     private let sessionStore: WCSessionStorage
@@ -29,3 +34,13 @@ class DeleteSessionService {
         networkingInteractor.unsubscribe(topic: topic)
     }
 }
+
+#if DEBUG
+final class MockDeleteSessionService: DeleteSessionServiceProtocol {
+    var deletedTopics: [String] = []
+
+    func delete(topic: String) async throws {
+        deletedTopics.append(topic)
+    }
+}
+#endif

--- a/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
@@ -26,7 +26,7 @@ final class SessionEngine {
     private var publishers = [AnyCancellable]()
     private let logger: ConsoleLogging
     private let sessionRequestsProvider: SessionRequestsProvider
-    private let invalidRequestsSanitiser: InvalidRequestsSanitiser
+    private let invalidRequestsSanitiser: InvalidRequestsSanitiserProtocol
 
     init(
         networkingInteractor: NetworkInteracting,
@@ -37,7 +37,7 @@ final class SessionEngine {
         sessionStore: WCSessionStorage,
         logger: ConsoleLogging,
         sessionRequestsProvider: SessionRequestsProvider,
-        invalidRequestsSanitiser: InvalidRequestsSanitiser
+        invalidRequestsSanitiser: InvalidRequestsSanitiserProtocol
     ) {
         self.networkingInteractor = networkingInteractor
         self.historyService = historyService

--- a/Sources/WalletConnectSign/Services/DisconnectService.swift
+++ b/Sources/WalletConnectSign/Services/DisconnectService.swift
@@ -1,20 +1,26 @@
 import Foundation
 
-class DisconnectService {
+final class DisconnectService {
+    
     enum Errors: Error {
         case sessionForTopicNotFound
     }
 
-    private let deleteSessionService: DeleteSessionService
+    private let deleteSessionService: DeleteSessionServiceProtocol
     private let sessionStorage: WCSessionStorage
+    private let invalidRequestsSanitiser: InvalidRequestsSanitiserProtocol
 
-    init(deleteSessionService: DeleteSessionService,
-         sessionStorage: WCSessionStorage) {
+    init(deleteSessionService: DeleteSessionServiceProtocol,
+         sessionStorage: WCSessionStorage,
+         invalidRequestsSanitiser: InvalidRequestsSanitiserProtocol) {
         self.deleteSessionService = deleteSessionService
         self.sessionStorage = sessionStorage
+        self.invalidRequestsSanitiser = invalidRequestsSanitiser
     }
 
     func disconnect(topic: String) async throws {
+        invalidRequestsSanitiser.removeSessionRequestsWith(topic: topic)
+        
         if sessionStorage.hasSession(forTopic: topic) {
             try await deleteSessionService.delete(topic: topic)
         } else {

--- a/Sources/WalletConnectSign/Services/HistoryService.swift
+++ b/Sources/WalletConnectSign/Services/HistoryService.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 protocol HistoryServiceProtocol {
+    
     func getPendingRequests() -> [(request: Request, context: VerifyContext?)]
+    
+    func getPendingRequests(topic: String) -> [(request: Request, context: VerifyContext?)]
 }
 
 final class HistoryService: HistoryServiceProtocol {
@@ -92,7 +95,11 @@ class MockHistoryService: HistoryServiceProtocol {
     var pendingRequests: [(request: Request, context: VerifyContext?)] = []
 
     func getPendingRequests() -> [(request: Request, context: VerifyContext?)] {
-        return pendingRequests
+        pendingRequests
+    }
+    
+    func getPendingRequests(topic: String) -> [(request: Request, context: VerifyContext?)] {
+        pendingRequests.filter { $0.0.topic == topic }
     }
 }
 #endif

--- a/Sources/WalletConnectSign/Services/InvalidRequestsSanitiser.swift
+++ b/Sources/WalletConnectSign/Services/InvalidRequestsSanitiser.swift
@@ -1,7 +1,14 @@
 
 import Foundation
 
-final class InvalidRequestsSanitiser {
+protocol InvalidRequestsSanitiserProtocol {
+    
+    func removeInvalidSessionRequests(validSessionTopics: Set<String>)
+    
+    func removeSessionRequestsWith(topic: String)
+}
+
+final class InvalidRequestsSanitiser: InvalidRequestsSanitiserProtocol {
     private let historyService: HistoryServiceProtocol
     private let history: RPCHistoryProtocol
 
@@ -17,4 +24,27 @@ final class InvalidRequestsSanitiser {
             history.deleteAll(forTopics: Array(invalidTopics))
         }
     }
+    
+    func removeSessionRequestsWith(topic: String) {
+        let pendingRequestTopics = historyService
+            .getPendingRequests(topic: topic)
+            .map(\.request)
+            .map(\.topic)
+        
+        history.deleteAll(forTopics: pendingRequestTopics)
+    }
 }
+
+#if DEBUG
+final class MockInvalidRequestsSanitiser: InvalidRequestsSanitiserProtocol {
+    var removedTopics: [String] = []
+    
+    func removeInvalidSessionRequests(validSessionTopics: Set<String>) {
+        removedTopics = removedTopics + Array(validSessionTopics)
+    }
+
+    func removeSessionRequestsWith(topic: String) {
+        removedTopics.append(topic)
+    }
+}
+#endif

--- a/Sources/WalletConnectSign/Sign/SignClientFactory.swift
+++ b/Sources/WalletConnectSign/Sign/SignClientFactory.swift
@@ -87,7 +87,7 @@ public struct SignClientFactory {
         )
         let cleanupService = SignCleanupService(pairingStore: pairingStore, sessionStore: sessionStore, kms: kms, sessionTopicToProposal: sessionTopicToProposal, networkInteractor: networkingClient, rpcHistory: rpcHistory)
         let deleteSessionService = DeleteSessionService(networkingInteractor: networkingClient, kms: kms, sessionStore: sessionStore, logger: logger)
-        let disconnectService = DisconnectService(deleteSessionService: deleteSessionService, sessionStorage: sessionStore)
+        let disconnectService = DisconnectService(deleteSessionService: deleteSessionService, sessionStorage: sessionStore, invalidRequestsSanitiser: invalidRequestsSanitiser)
         let sessionPingService = SessionPingService(sessionStorage: sessionStore, networkingInteractor: networkingClient, logger: logger)
         let pairingPingService = PairingPingService(pairingStorage: pairingStore, networkingInteractor: networkingClient, logger: logger)
         let appProposerService = AppProposeService(metadata: metadata, networkingInteractor: networkingClient, kms: kms, logger: logger)

--- a/Tests/WalletConnectSignTests/DisconnectServiceTests.swift
+++ b/Tests/WalletConnectSignTests/DisconnectServiceTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import WalletConnectSign
+@testable import WalletConnectUtils
+
+final class DisconnectServiceTests: XCTestCase {
+   
+    var mockDeleteSessionService: MockDeleteSessionService!
+    var mockStorage: WCSessionStorageMock!
+    var mockSanitiser: MockInvalidRequestsSanitiser!
+    var sut: DisconnectService!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        mockDeleteSessionService = MockDeleteSessionService()
+        mockStorage = WCSessionStorageMock()
+        mockSanitiser = MockInvalidRequestsSanitiser()
+        sut = DisconnectService(
+            deleteSessionService: mockDeleteSessionService,
+            sessionStorage: mockStorage,
+            invalidRequestsSanitiser: mockSanitiser
+        )
+    }
+    
+    override func tearDownWithError() throws {
+        sut = nil
+        mockSanitiser = nil
+        mockStorage = nil
+        mockDeleteSessionService = nil
+        
+        try super.tearDownWithError()
+    }
+    
+    func test_disconnect_clears_requests_for_topic() async throws {
+        let topicsToRemove = [ "topic1", "topic2", "topic3" ]
+        
+        for topic in topicsToRemove {
+            mockStorage.setSession(
+                WCSession.stub(
+                    topic: topic,
+                    namespaces: SessionNamespace.stubDictionary()
+                )
+            )
+        }
+        
+        for topic in topicsToRemove {
+            try await sut.disconnect(topic: topic)
+        }
+        
+        XCTAssertEqual(mockSanitiser.removedTopics, topicsToRemove)
+    }
+}


### PR DESCRIPTION
# Description

This is a follow up to https://github.com/WalletConnect/WalletConnectSwiftV2/pull/1353.

In addition to clearing stale requests on initialisation, this PR also makes sure requests related to the session that is being `disconnect`ed are also cleared.

Resolves #1343

## How Has This Been Tested?

> [!NOTE]
> This has not yet been tested against the bug as I am still unable to reproduce, this will be tested before merging.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
