### PR TITLE
Remove pending requests on session expiration

### DIFF
--- a/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
+++ b/Sources/WalletConnectSign/Engine/Common/SessionEngine.swift
@@ -19,7 +19,7 @@ final class SessionEngine {
 
     private let sessionStore: WCSessionStorage
     private let networkingInteractor: NetworkInteracting
-    private let historyService: HistoryService
+    private let historyService: HistoryServiceProtocol
     private let verifyContextStore: CodableStore<VerifyContext>
     private let verifyClient: VerifyClientProtocol
     private let kms: KeyManagementServiceProtocol
@@ -30,7 +30,7 @@ final class SessionEngine {
 
     init(
         networkingInteractor: NetworkInteracting,
-        historyService: HistoryService,
+        historyService: HistoryServiceProtocol,
         verifyContextStore: CodableStore<VerifyContext>,
         verifyClient: VerifyClientProtocol,
         kms: KeyManagementServiceProtocol,
@@ -202,6 +202,7 @@ private extension SessionEngine {
 
     func setupExpirationSubscriptions() {
         sessionStore.onSessionExpiration = { [weak self] session in
+            self?.historyService.removePendingRequest(topic: session.topic)
             self?.kms.deletePrivateKey(for: session.selfParticipant.publicKey)
             self?.kms.deleteAgreementSecret(for: session.topic)
         }

--- a/Sources/WalletConnectSign/Sign/SessionRequestsProvider.swift
+++ b/Sources/WalletConnectSign/Sign/SessionRequestsProvider.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 class SessionRequestsProvider {
-    private let historyService: HistoryService
+    private let historyService: HistoryServiceProtocol
     private var sessionRequestPublisherSubject = PassthroughSubject<(request: Request, context: VerifyContext?), Never>()
     private var lastEmitTime: Date?
     private let debounceInterval: TimeInterval = 1
@@ -11,7 +11,7 @@ class SessionRequestsProvider {
         sessionRequestPublisherSubject.eraseToAnyPublisher()
     }
 
-    init(historyService: HistoryService) {
+    init(historyService: HistoryServiceProtocol) {
         self.historyService = historyService
     }
 

--- a/Sources/WalletConnectUtils/RPCHistory/RPCHistory.swift
+++ b/Sources/WalletConnectUtils/RPCHistory/RPCHistory.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 public protocol RPCHistoryProtocol {
+    
+    func deleteAll(forTopic topic: String)
+    
     func deleteAll(forTopics topics: [String])
 }
 
@@ -152,6 +155,10 @@ extension RPCHistory {
 #if DEBUG
 class MockRPCHistory: RPCHistoryProtocol {
     var deletedTopics: [String] = []
+    
+    func deleteAll(forTopic topic: String) {
+        deletedTopics.append(topic)
+    }
 
     func deleteAll(forTopics topics: [String]) {
         deletedTopics.append(contentsOf: topics)


### PR DESCRIPTION
# Description

This is a follow up to https://github.com/WalletConnect/WalletConnectSwiftV2/pull/1353.

In addition to clearing stale requests on initialisation, this PR also makes sure requests related to the session are also cleared when the session expires.

Resolves #1343

## How Has This Been Tested?

> [!NOTE]
> This has not yet been tested against the bug as I am still unable to reproduce, this will be tested before merging.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
