### PR TITLE
chore(rejection tags): Session rejection tags

### DIFF
--- a/Sources/WalletConnectSign/Auth/Link/LinkAuthRequestSubscriber.swift
+++ b/Sources/WalletConnectSign/Auth/Link/LinkAuthRequestSubscriber.swift
@@ -29,7 +29,8 @@ class LinkAuthRequestSubscriber {
 
     private func subscribeForRequest() {
 
-        envelopesDispatcher.requestSubscription(on: SessionAuthenticatedProtocolMethod().method)
+        envelopesDispatcher
+            .requestSubscription(on: SessionAuthenticatedProtocolMethod.responseApprove().method)
             .sink { [unowned self] (payload: RequestSubscriptionPayload<SessionAuthenticateRequestParams>) in
 
                 logger.debug("LinkAuthRequestSubscriber: Received request")

--- a/Sources/WalletConnectSign/Auth/Link/LinkAuthRequester.swift
+++ b/Sources/WalletConnectSign/Auth/Link/LinkAuthRequester.swift
@@ -37,7 +37,7 @@ actor LinkAuthRequester {
         var params = params
         let pubKey = try kms.createX25519KeyPair()
         let responseTopic = pubKey.rawRepresentation.sha256().toHexString()
-        let protocolMethod = SessionAuthenticatedProtocolMethod(ttl: params.ttl)
+        let protocolMethod = SessionAuthenticatedProtocolMethod.responseApprove(ttl: params.ttl)
         guard let chainNamespace = Blockchain(params.chains.first!)?.namespace,
               chainNamespace == "eip155"
         else {

--- a/Sources/WalletConnectSign/Auth/Services/App/AuthResponseSubscriber.swift
+++ b/Sources/WalletConnectSign/Auth/Services/App/AuthResponseSubscriber.swift
@@ -52,13 +52,15 @@ class AuthResponseSubscriber {
     }
 
     private func subscribeForResponse() {
-        networkingInteractor.responseErrorSubscription(on: SessionAuthenticatedProtocolMethod())
+        networkingInteractor
+            .responseErrorSubscription(on: SessionAuthenticatedProtocolMethod.responseApprove())
             .sink { [unowned self] (payload: ResponseSubscriptionErrorPayload<SessionAuthenticateRequestParams>) in
                 guard let error = AuthError(code: payload.error.code) else { return }
                 authResponsePublisherSubject.send((payload.id, .failure(error)))                
             }.store(in: &publishers)
 
-        networkingInteractor.responseSubscription(on: SessionAuthenticatedProtocolMethod())
+        networkingInteractor
+            .responseSubscription(on: SessionAuthenticatedProtocolMethod.responseApprove())
             .sink { [unowned self] (payload: ResponseSubscriptionPayload<SessionAuthenticateRequestParams, SessionAuthenticateResponseParams>)  in
 
                 let transportType = getTransportTypeUpgradeIfPossible(peerMetadata: payload.response.responder.metadata, requestId: payload.id)
@@ -86,13 +88,13 @@ class AuthResponseSubscriber {
     }
 
     private func subscribeForLinkResponse() {
-        linkEnvelopesDispatcher.responseErrorSubscription(on: SessionAuthenticatedProtocolMethod())
+        linkEnvelopesDispatcher.responseErrorSubscription(on: SessionAuthenticatedProtocolMethod.responseApprove())
             .sink { [unowned self] (payload: ResponseSubscriptionErrorPayload<SessionAuthenticateRequestParams>) in
                 guard let error = AuthError(code: payload.error.code) else { return }
                 authResponsePublisherSubject.send((payload.id, .failure(error)))
             }.store(in: &publishers)
 
-        linkEnvelopesDispatcher.responseSubscription(on: SessionAuthenticatedProtocolMethod())
+        linkEnvelopesDispatcher.responseSubscription(on: SessionAuthenticatedProtocolMethod.responseApprove())
             .sink { [unowned self] (payload: ResponseSubscriptionPayload<SessionAuthenticateRequestParams, SessionAuthenticateResponseParams>)  in
 
                 let pairingTopic = payload.topic

--- a/Sources/WalletConnectSign/Auth/Services/App/AuthenticateTransportTypeSwitcher.swift
+++ b/Sources/WalletConnectSign/Auth/Services/App/AuthenticateTransportTypeSwitcher.swift
@@ -45,7 +45,9 @@ class AuthenticateTransportTypeSwitcher {
             // Continue with relay if the error is walletLinkSupportNotProven
         }
 
-        let pairingURI = try await pairingClient.create(methods: [SessionAuthenticatedProtocolMethod().method])
+        let pairingURI = try await pairingClient.create(
+            methods: [SessionAuthenticatedProtocolMethod.responseApprove().method]
+        )
         logger.debug("Requesting Authentication on existing pairing")
         try await appRequestService.request(params: params, topic: pairingURI.topic)
 

--- a/Sources/WalletConnectSign/Auth/Services/App/SessionAuthRequestService.swift
+++ b/Sources/WalletConnectSign/Auth/Services/App/SessionAuthRequestService.swift
@@ -29,7 +29,7 @@ actor SessionAuthRequestService {
         var params = params
         let pubKey = try kms.createX25519KeyPair()
         let responseTopic = pubKey.rawRepresentation.sha256().toHexString()
-        let protocolMethod = SessionAuthenticatedProtocolMethod(ttl: params.ttl)
+        let protocolMethod = SessionAuthenticatedProtocolMethod.responseApprove(ttl: params.ttl)
         guard let chainNamespace = Blockchain(params.chains.first!)?.namespace,
               chainNamespace == "eip155"
         else {

--- a/Sources/WalletConnectSign/Auth/Services/Wallet/AuthRequestSubscriber.swift
+++ b/Sources/WalletConnectSign/Auth/Services/Wallet/AuthRequestSubscriber.swift
@@ -36,7 +36,7 @@ class AuthRequestSubscriber {
     }
 
     private func subscribeForRequest() {
-        pairingRegisterer.register(method: SessionAuthenticatedProtocolMethod())
+        pairingRegisterer.register(method: SessionAuthenticatedProtocolMethod.responseApprove())
             .sink { [unowned self] (payload: RequestSubscriptionPayload<SessionAuthenticateRequestParams>) in
 
                 guard !payload.request.isExpired() else {
@@ -70,10 +70,15 @@ class AuthRequestSubscriber {
             }.store(in: &publishers)
     }
 
-    func respondError(payload: SubscriptionPayload, reason: SignReasonCode) {
+    private func respondError(payload: SubscriptionPayload, reason: SignReasonCode) {
         Task(priority: .high) {
             do {
-                try await networkingInteractor.respondError(topic: payload.topic, requestId: payload.id, protocolMethod: SessionAuthenticatedProtocolMethod(), reason: reason)
+                try await networkingInteractor.respondError(
+                    topic: payload.topic,
+                    requestId: payload.id,
+                    protocolMethod: SessionAuthenticatedProtocolMethod.responseAutoReject(),
+                    reason: reason
+                )
             } catch {
                 logger.error("Respond Error failed with: \(error.localizedDescription)")
             }

--- a/Sources/WalletConnectSign/Auth/Services/Wallet/SessionAuthenticateResponder.swift
+++ b/Sources/WalletConnectSign/Auth/Services/Wallet/SessionAuthenticateResponder.swift
@@ -53,7 +53,13 @@ actor SessionAuthenticateResponder {
         let responseParams = SessionAuthenticateResponseParams(responder: selfParticipant, cacaos: auths)
 
         let response = RPCResponse(id: requestId, result: responseParams)
-        try await networkingInteractor.respond(topic: responseTopic, response: response, protocolMethod: SessionAuthenticatedProtocolMethod(), envelopeType: .type1(pubKey: responseKeys.publicKey.rawRepresentation))
+        
+        try await networkingInteractor.respond(
+            topic: responseTopic,
+            response: response,
+            protocolMethod: SessionAuthenticatedProtocolMethod.responseApprove(),
+            envelopeType: .type1(pubKey: responseKeys.publicKey.rawRepresentation)
+        )
 
 
         let session = try util.createSession(

--- a/Sources/WalletConnectSign/Auth/SessionAuthenticatedProtocolMethod.swift
+++ b/Sources/WalletConnectSign/Auth/SessionAuthenticatedProtocolMethod.swift
@@ -1,17 +1,47 @@
 import Foundation
 
 struct SessionAuthenticatedProtocolMethod: ProtocolMethod {
+    
+    enum Tag: Int {
+        case sessionAuthenticate = 1116
+        case sessionAuthenticateResponseApprove = 1117
+        case sessionAuthenticateResponseReject = 1118
+        case sessionAuthenticateResponseAutoReject = 1119
+    }
+    
     let method: String = "wc_sessionAuthenticate"
 
-    let requestConfig = RelayConfig(tag: 1116, prompt: true, ttl: 3600)
+    let requestConfig: RelayConfig
+    
+    let responseConfig: RelayConfig
 
-    let responseConfig = RelayConfig(tag: 1117, prompt: false, ttl: 3600)
-
-
-    static let defaultTtl: TimeInterval = 3600
-    private let ttl: Int
-
-    init(ttl: TimeInterval = Self.defaultTtl) {
-        self.ttl = Int(ttl)
+    static let defaultTtl: TimeInterval = 300
+    
+    private init(
+        ttl: TimeInterval,
+        responseTag: Tag
+    ) {
+        self.requestConfig = RelayConfig(
+            tag: Tag.sessionAuthenticate.rawValue,
+            prompt: true,
+            ttl: Int(ttl)
+        )
+        self.responseConfig = RelayConfig(
+            tag: responseTag.rawValue,
+            prompt: false,
+            ttl: Int(ttl)
+        )
+    }
+    
+    static func responseApprove(ttl: TimeInterval = Self.defaultTtl) -> Self {
+        Self(ttl: ttl, responseTag: .sessionAuthenticateResponseApprove)
+    }
+    
+    static func responseReject(ttl: TimeInterval = Self.defaultTtl) -> Self {
+        Self(ttl: ttl, responseTag: .sessionAuthenticateResponseReject)
+    }
+    
+    static func responseAutoReject(ttl: TimeInterval = Self.defaultTtl) -> Self {
+        Self(ttl: ttl, responseTag: .sessionAuthenticateResponseAutoReject)
     }
 }

--- a/Sources/WalletConnectSign/LinkAndRelayDispatchers/WalletErrorResponder.swift
+++ b/Sources/WalletConnectSign/LinkAndRelayDispatchers/WalletErrorResponder.swift
@@ -48,7 +48,13 @@ actor WalletErrorResponder {
 
     private func respondErrorRelay(_ error: AuthError, requestId: RPCID, topic: String, type1EnvelopeKey: Data) async throws {
         let envelopeType = Envelope.EnvelopeType.type1(pubKey: type1EnvelopeKey)
-        try await networkingInteractor.respondError(topic: topic, requestId: requestId, protocolMethod: SessionAuthenticatedProtocolMethod(), reason: error, envelopeType: envelopeType)
+        try await networkingInteractor.respondError(
+            topic: topic,
+            requestId: requestId,
+            protocolMethod: SessionAuthenticatedProtocolMethod.responseReject(),
+            reason: error,
+            envelopeType: envelopeType
+        )
     }
 
     private func respondErrorLinkMode(_ error: AuthError, requestId: RPCID, topic: String, type1EnvelopeKey: Data) async throws -> String {

--- a/Sources/WalletConnectSign/Services/App/AppProposeService.swift
+++ b/Sources/WalletConnectSign/Services/App/AppProposeService.swift
@@ -33,7 +33,7 @@ final class AppProposeService {
         if let sessionProperties {
             try SessionProperties.validate(sessionProperties)
         }
-        let protocolMethod = SessionProposeProtocolMethod()
+        let protocolMethod = SessionProposeProtocolMethod.responseApprove()
         let publicKey = try! kms.createX25519KeyPair()
         let proposer = Participant(
             publicKey: publicKey.hexRepresentation,

--- a/Sources/WalletConnectSign/Types/ProtocolMethods/SessionProposeProtocolMethod.swift
+++ b/Sources/WalletConnectSign/Types/ProtocolMethods/SessionProposeProtocolMethod.swift
@@ -2,8 +2,45 @@ import Foundation
 
 struct SessionProposeProtocolMethod: ProtocolMethod {
     let method: String = "wc_sessionPropose"
+    
+    enum Tag: Int {
+        case sessionPropose = 1100
+        case sessionProposeResponseApprove = 1101
+        case sessionProposeResponseReject = 1120
+        case sessionProposeResponseAutoReject = 1121
+    }
 
-    let requestConfig = RelayConfig(tag: 1100, prompt: true, ttl: 300)
+    let requestConfig: RelayConfig
 
-    let responseConfig = RelayConfig(tag: 1101, prompt: false, ttl: 300)
+    let responseConfig: RelayConfig
+   
+    static let defaultTtl: TimeInterval = 300
+    
+    private init(
+        ttl: TimeInterval,
+        responseTag: Tag
+    ) {
+        self.requestConfig = RelayConfig(
+            tag: Tag.sessionPropose.rawValue,
+            prompt: true,
+            ttl: Int(ttl)
+        )
+        self.responseConfig = RelayConfig(
+            tag: responseTag.rawValue,
+            prompt: false,
+            ttl: Int(ttl)
+        )
+    }
+    
+    static func responseApprove(ttl: TimeInterval = Self.defaultTtl) -> Self {
+        Self(ttl: ttl, responseTag: .sessionProposeResponseApprove)
+    }
+    
+    static func responseReject(ttl: TimeInterval = Self.defaultTtl) -> Self {
+        Self(ttl: ttl, responseTag: .sessionProposeResponseReject)
+    }
+    
+    static func responseAutoReject(ttl: TimeInterval = Self.defaultTtl) -> Self {
+        Self(ttl: ttl, responseTag: .sessionProposeResponseAutoReject)
+    }
 }


### PR DESCRIPTION
# Description

This PR adds specific rejection tags for `sessionPropose` and `sessionAuthenticate` to disambiguate user rejection from genuine failures. 

## How Has This Been Tested?

This will be manually tested.
