### PR TITLE
Fixed the issue where account information retrieved from Wallet was being displayed twice.

### DIFF
--- a/Example/DApp/Modules/Sign/SignPresenter.swift
+++ b/Example/DApp/Modules/Sign/SignPresenter.swift
@@ -221,6 +221,7 @@ extension SignPresenter {
             self.session = session
             session.namespaces.values.forEach { namespace in
                 namespace.accounts.forEach { account in
+                    accountsDetails.removeAll()                
                     accountsDetails.append(
                         AccountDetails(
                             chain: account.blockchainIdentifier,

--- a/Example/DApp/Modules/Sign/SignView.swift
+++ b/Example/DApp/Modules/Sign/SignView.swift
@@ -96,7 +96,7 @@ struct SignView: View {
                         .padding(12)
                     } else {
                         VStack {
-                            ForEach(presenter.accountsDetails, id: \.chain) { account in
+                            ForEach(presenter.accountsDetails, id: \.account) { account in
                                 Button {
                                     presenter.presentSessionAccount(sessionAccount: account)
                                 } label: {


### PR DESCRIPTION
# Description

1. Tap Connect with Web3Modal
2. Choose MetaMask
3. Select multi accounts in metamask and confirm
4. Back to DApp example
5. All accounts will be displayed twice, and all with the same address.


